### PR TITLE
Chore: forbid superfluous parentheses

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,3 +20,4 @@ rules:
     ClassDeclaration: true,
     ArrowFunctionExpression: true
   }}]
+  no-extra-parens: 1

--- a/src/ElementUtilities.js
+++ b/src/ElementUtilities.js
@@ -21,7 +21,7 @@ const findClosest = (el, selector) => {
  * @return {boolean}        Whether table ancestor of 'el' is found
  */
 const isNestedInTable = (el) => {
-  return (findClosest(el, 'table') !== null)
+  return findClosest(el, 'table') !== null
 }
 
 export default {

--- a/test/WidenImage.js
+++ b/test/WidenImage.js
@@ -34,14 +34,14 @@ describe('WidenImage', () => {
 
     it('should indicate two images from the fixture be widened', () => {
       const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return (shouldWidenImage(image) && image.classList.contains('imageWhichShouldWiden'))
+        return shouldWidenImage(image) && image.classList.contains('imageWhichShouldWiden')
       })
       assert.ok(images.length === 2)
     })
 
     it('should indicate four images from the fixture not be widened', () => {
       const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return (!shouldWidenImage(image) && image.classList.contains('imageWhichShouldNotWiden'))
+        return !shouldWidenImage(image) && image.classList.contains('imageWhichShouldNotWiden')
       })
       assert.ok(images.length === 4)
     })
@@ -50,7 +50,7 @@ describe('WidenImage', () => {
   describe('maybeWidenImage()', () => {
     it('maybeWidenImage always has same return value as shouldWidenImage', () => {
       const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return (shouldWidenImage(image) === maybeWidenImage(image))
+        return shouldWidenImage(image) === maybeWidenImage(image)
       })
       assert.ok(images.length === 6)
     })
@@ -105,7 +105,7 @@ describe('WidenImage', () => {
 
     it('two images from the fixture are actually widened', () => {
       const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return (maybeWidenImage(image) && image.classList.contains('wideImageOverride'))
+        return maybeWidenImage(image) && image.classList.contains('wideImageOverride')
       })
       assert.ok(images.length === 2)
     })


### PR DESCRIPTION
Add rule to prohibit the usage of unnecessary parentheses and fix
offenders.