### PR TITLE
Breaking: rename applib to wikimedia-page-library

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v2.0.0
+- Breaking: rename applib to wikimedia-page-library including build products
+
 ### v1.2.1
 - Fix: center widened image captions from Parsoid
 - Chore: update CollapseTable tests to be more consistent

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "applib",
+  "name": "wikimedia-page-library",
   "version": "1.2.0",
   "description": "Cross-platform JavaScript and CSS library for Wikimedia apps",
   "keywords": [
@@ -15,10 +15,10 @@
     "JavaScript",
     "CSS"
   ],
-  "homepage": "https://github.com/wikimedia/applib",
-  "repository": "github:wikimedia/applib",
-  "bugs": "https://github.com/wikimedia/applib/issues",
-  "main": "build/applib.js",
+  "homepage": "https://github.com/wikimedia/wikimedia-page-library",
+  "repository": "github:wikimedia/wikimedia-page-library",
+  "bugs": "https://github.com/wikimedia/wikimedia-page-library/issues",
+  "main": "build/wikimedia-page-library.js",
   "scripts": {
     "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json",
     "lint:all": "npm run -s lint .",

--- a/readme.md
+++ b/readme.md
@@ -1,19 +1,19 @@
-# applib
+# wikimedia-page-library
 Library for common JavaScript transforms and CSS used by both the Android and iOS Wikipedia apps
 
 ## Background
-Presently we are consolidating duplicate Android and iOS Wikipedia app implementations of certain JavaScript transformations, such as image widening. **Applib** is where we are placing these consolidated JavaScript transform implementations. 
+Presently we are consolidating duplicate Android and iOS Wikipedia app implementations of certain JavaScript transformations, such as image widening. **wikimedia-page-library** is where we are placing these consolidated JavaScript transform implementations. 
 
-## What Applib is for
+## What wikimedia-page-library is for
 * JavaScript transforms common to **both** the Android and iOS Wikipedia apps.
 
-## What Applib is not for
+## What wikimedia-page-library is not for
 * Android or iOS **specific** JS or CSS.
-* CSS unrelated to a particular JavaScript transform. *In the future we may re-evaluate this for CSS common between the Android and iOS apps, but for right now the only CSS in Applib should be CSS directly needed by a particular JavaScript transform.*
+* CSS unrelated to a particular JavaScript transform. *In the future we may re-evaluate this for CSS common between the Android and iOS apps, but for right now the only CSS in wikimedia-page-library should be CSS directly needed by a particular JavaScript transform.*
 
-## What Applib delivers
-* **applib.js** bundle of all transform JS
-* **applib.css** bundle of all CSS required by the bundled transform JS
+## What wikimedia-page-library delivers
+* **wikimedia-page-library.js** bundle of all transform JS
+* **wikimedia-page-library.css** bundle of all CSS required by the bundled transform JS
 
 ## Conventions
 

--- a/test/CollapseTable.js
+++ b/test/CollapseTable.js
@@ -1,10 +1,10 @@
-import applib from '../build/applib'
 import assert from 'assert'
 import domino from 'domino'
+import pagelib from '../build/wikimedia-page-library'
 
 describe('CollapseTable', () => {
   describe('getTableHeader()', () => {
-    const getTableHeader = applib.CollapseTable.getTableHeader
+    const getTableHeader = pagelib.CollapseTable.getTableHeader
 
     it('when no table, shouldn\'t find headers', () => {
       const doc = domino.createDocument('<html></html>')

--- a/test/ElementUtilities.js
+++ b/test/ElementUtilities.js
@@ -1,8 +1,8 @@
-import applib from '../build/applib'
 import assert from 'assert'
 import fixtureIO from './utilities/FixtureIO'
+import pagelib from '../build/wikimedia-page-library'
 
-const elementUtilities = applib.test.ElementUtilities
+const elementUtilities = pagelib.test.ElementUtilities
 let document = null
 
 describe('ElementUtilities', () => {

--- a/test/WidenImage.js
+++ b/test/WidenImage.js
@@ -1,11 +1,11 @@
-import applib from '../build/applib'
 import assert from 'assert'
 import fixtureIO from './utilities/FixtureIO'
+import pagelib from '../build/wikimedia-page-library'
 import styleMocking from './utilities/StyleMocking'
 
-const maybeWidenImage = applib.WidenImage.maybeWidenImage
-const shouldWidenImage = applib.WidenImage.test.shouldWidenImage
-const widenAncestors = applib.WidenImage.test.widenAncestors
+const maybeWidenImage = pagelib.WidenImage.maybeWidenImage
+const shouldWidenImage = pagelib.WidenImage.test.shouldWidenImage
+const widenAncestors = pagelib.WidenImage.test.widenAncestors
 
 let document = null
 


### PR DESCRIPTION
This patch renames applib to wikimedia-page-library. As part of this
change, breaking build product renames are made for the JavaScript and
CSS outputs and the NPM references are updated. `pagelib` is used in
JavaScript to keep code at a readable balance between bloat and cryptic.