### PR TITLE
Introduce polyfill for matching element with selector.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,19 @@
+### v2.0.1
+- Fix: use polyfill for Element.matches()
+
 ### v2.0.0
 - Breaking: rename applib to wikimedia-page-library including build products
 - Breaking: divide build products into transform and override files
-- Doc: overhaul readme
 
-### v1.2.1
+### v1.2.3
+- Mislabeled package. Do not use.
+
+### v1.2.2
 - Fix: center widened image captions from Parsoid
 - Chore: update CollapseTable tests to be more consistent
+
+### v1.2.1
+- Broken package. Do not use.
 
 ### v1.2.0
 - New: JS and CSS for image widening transform

--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -2,7 +2,7 @@
  * Polyfill function that tells whether a given element matches a selector.
  * @param {!Element} el Element
  * @param {!string} selector Selector to look for
- * @returns {boolean} Whether the element matches the selector
+ * @returns {!boolean} Whether the element matches the selector
  */
 const matchesSelectorCompat = (el, selector) => {
   if (el.matches) {

--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -1,4 +1,21 @@
 /**
+ * Polyfill function that tells whether a given element matches a selector.
+ * @param {!Element} el Element
+ * @param {!string} selector Selector to look for
+ * @returns {boolean} Whether the element matches the selector
+ */
+const matchesSelectorCompat = (el, selector) => {
+  if (el.matches) {
+    return el.matches(selector)
+  } else if (el.matchesSelector) {
+    return el.matchesSelector(selector)
+  } else if (el.webkitMatchesSelector) {
+    return el.webkitMatchesSelector(selector)
+  }
+  return false
+}
+
+/**
  * Returns closest ancestor of element which matches selector.
  * Similar to 'closest' methods as seen here:
  *  https://api.jquery.com/closest/
@@ -10,7 +27,7 @@
 const findClosestAncestor = (el, selector) => {
   let parentElement
   for (parentElement = el.parentElement;
-    parentElement && !parentElement.matches(selector);
+    parentElement && !matchesSelectorCompat(parentElement, selector);
     parentElement = parentElement.parentElement) {
     // Intentionally empty.
   }


### PR DESCRIPTION
Some older versions of the Android WebView do not provide the `matches()`
method on its elements. They do, however, provide an equivalent method
called `webkitMatchesSelector()`, and I've also observed a Samsung flavor
of WebView that provides `matchesSelector()`. This patch introduces a
polyfill that tries to use all three of these variations.

This is currently causing a regression where image widening is not working in API <19.