### PR TITLE
Chore: upgrade dependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v2.0.2
+- Chore: upgrade dependencies
+
 ### v2.0.1
 - Fix: use polyfill for Element.matches()
 

--- a/package.json
+++ b/package.json
@@ -42,19 +42,21 @@
     "build"
   ],
   "devDependencies": {
-    "rollup-plugin-css-porter": "0.1.2",
     "babel-plugin-external-helpers": "6.22.0",
-    "babel-preset-env": "1.1.10",
-    "babel-register": "6.23.0",
+    "babel-preset-env": "1.4.0",
+    "babel-register": "6.24.1",
     "domino": "1.0.28",
-    "eslint": "3.16.1",
-    "eslint-config-node-services": "2.0.1",
+    "eslint": "3.19.0",
+    "eslint-config-node-services": "2.2.1",
+    "eslint-config-wikimedia": "0.3.0",
+    "eslint-plugin-jsdoc": "3.0.2",
     "eslint-plugin-json": "1.2.0",
-    "mocha": "3.2.0",
-    "npm-check-updates": "2.10.3",
+    "mocha": "3.3.0",
+    "npm-check-updates": "2.11.0",
     "pre-commit": "1.2.2",
-    "rollup": "0.41.4",
-    "rollup-plugin-babel": "2.7.1"
+    "rollup": "0.41.6",
+    "rollup-plugin-babel": "2.7.1",
+    "rollup-plugin-css-porter": "0.1.2"
   },
   "license": "Apache-2.0"
 }

--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -2,7 +2,7 @@
  * Polyfill function that tells whether a given element matches a selector.
  * @param {!Element} el Element
  * @param {!string} selector Selector to look for
- * @returns {!boolean} Whether the element matches the selector
+ * @return {!boolean} Whether the element matches the selector
  */
 const matchesSelectorCompat = (el, selector) => {
   if (el.matches) {


### PR DESCRIPTION
- babel-preset-env v1.1.10 → v1.4.0
  - Many bug fixes

  https://github.com/babel/babel-preset-env/releases/tag/v1.1.11
  https://github.com/babel/babel-preset-env/releases/tag/v1.2.0
  https://github.com/babel/babel-preset-env/releases/tag/v1.2.1
  https://github.com/babel/babel-preset-env/releases/tag/v1.2.2
  https://github.com/babel/babel-preset-env/releases/tag/v1.3.0
  https://github.com/babel/babel-preset-env/releases/tag/v1.3.3
  https://github.com/babel/babel-preset-env/releases/tag/v1.4.0

- babel-register v6.23.0 → v6.24.1

- eslint v3.16.1 → v3.19.0, eslint-config-node-services v2.0.1  → v2.2.1
  - New: JSDoc linting, eslint-plugin-jsdoc v3.0.2
  - New: ESLint config descends from greater Wikimedia config,
    eslint-config-wikimedia v0.3.0
  - Many new rules available in ESLint; see release notes

  https://github.com/eslint/eslint/releases

- mocha v3.2.0 → v3.3.0
  - New: code coverage (appears to require additional dependencies)

  https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#330--2017-04-24

- npm-check-updates v2.10.3 → v2.11.0
  - New: timeout option

  https://github.com/tjunnone/npm-check-updates/releases

- rollup v0.41.4 → v0.41.6

  https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0415
  https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0416