### PR TITLE
Chore: omit needless parentheses and braces on arrow functions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,3 +27,7 @@ rules:
   no-cond-assign: [2, always]
   no-implicit-coercion: [1, {allow: ['!!']}]
   no-param-reassign: 1
+
+  # ECMAScript 6
+  arrow-body-style: 1
+  arrow-parens: [1, as-needed]

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -96,11 +96,9 @@ const toggleCollapseClickCallback = function(footerDivClickCallback) {
  * @param {!HTMLElement} table
  * @return {!boolean} true if table should be collapsed, false otherwise.
  */
-const shouldTableBeCollapsed = (table) => {
+const shouldTableBeCollapsed = table => {
   const classBlacklist = ['navbox', 'vertical-navbox', 'navbox-inner', 'metadata', 'mbox-small']
-  const blacklistIntersects = classBlacklist.some((clazz) => {
-    return table.classList.contains(clazz)
-  })
+  const blacklistIntersects = classBlacklist.some(clazz => table.classList.contains(clazz))
   return table.style.display !== 'none' && !blacklistIntersects
 }
 
@@ -108,9 +106,7 @@ const shouldTableBeCollapsed = (table) => {
  * @param {!Element} element
  * @return {!boolean} true if element is an infobox, false otherwise.
  */
-const isInfobox = (element) => {
-  return element.classList.contains('infobox')
-}
+const isInfobox = element => element.classList.contains('infobox')
 
 /**
  * @param {!Document} document
@@ -235,7 +231,7 @@ const collapseTables = (document, content, pageTitle, isMainPage, infoboxTitle, 
  * @param  {?Element} element
  * @return {void}
 */
-const expandCollapsedTableIfItContainsElement = (element) => {
+const expandCollapsedTableIfItContainsElement = element => {
   if (element) {
     const containerSelector = '[class*="app_table_container"]'
     const container = elementUtilities.findClosestAncestor(element, containerSelector)

--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -41,9 +41,7 @@ const findClosestAncestor = (el, selector) => {
  * @param  {!Element}  el   Element
  * @return {boolean}        Whether table ancestor of 'el' is found
  */
-const isNestedInTable = (el) => {
-  return Boolean(findClosestAncestor(el, 'table'))
-}
+const isNestedInTable = el => Boolean(findClosestAncestor(el, 'table'))
 
 export default {
   matchesSelectorCompat,

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -8,7 +8,7 @@ import elementUtilities from './ElementUtilities'
  * can take effect.
  * @param  {!HTMLElement} el Element whose ancestors will be widened
  */
-const widenAncestors = (el) => {
+const widenAncestors = el => {
   for (let parentElement = el.parentElement;
     parentElement && !parentElement.classList.contains('content_block');
     parentElement = parentElement.parentElement) {
@@ -29,7 +29,7 @@ const widenAncestors = (el) => {
  * @param  {!HTMLElement} image   The image in question
  * @return {boolean}              Whether 'image' should be widened
  */
-const shouldWidenImage = (image) => {
+const shouldWidenImage = image => {
   // Images within a "<div class='noresize'>...</div>" should not be widened.
   // Example exhibiting links overlaying such an image:
   //   'enwiki > Counties of England > Scope and structure > Local government'
@@ -66,7 +66,7 @@ const shouldWidenImage = (image) => {
  * Removes barriers to images widening taking effect.
  * @param  {!HTMLElement} image   The image in question
  */
-const makeRoomForImageWidening = (image) => {
+const makeRoomForImageWidening = image => {
   widenAncestors(image)
 
   // Remove width and height attributes so wideImageOverride width percentages can take effect.
@@ -78,7 +78,7 @@ const makeRoomForImageWidening = (image) => {
  * Widens the image.
  * @param  {!HTMLElement} image   The image in question
  */
-const widenImage = (image) => {
+const widenImage = image => {
   makeRoomForImageWidening(image)
   image.classList.add('wideImageOverride')
 }
@@ -88,7 +88,7 @@ const widenImage = (image) => {
  * @param  {!HTMLElement} image   The image in question
  * @return {boolean}              Whether or not 'image' was widened
  */
-const maybeWidenImage = (image) => {
+const maybeWidenImage = image => {
   if (shouldWidenImage(image)) {
     widenImage(image)
     return true

--- a/test/transform/CollapseTable.js
+++ b/test/transform/CollapseTable.js
@@ -512,7 +512,7 @@ describe('CollapseTable', () => {
           expandCollapsedTableIfItContainsElement(element)
         })
 
-        it('and table is collapsed, the table is expanded', (done) => {
+        it('and table is collapsed, the table is expanded', done => {
           const html = `
             <div class=app_table_container>
               <div class=app_table_collapsed_open></div>

--- a/test/transform/WidenImage.js
+++ b/test/transform/WidenImage.js
@@ -33,25 +33,22 @@ describe('WidenImage', () => {
     })
 
     it('should indicate two images from the fixture be widened', () => {
-      const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return shouldWidenImage(image) && image.classList.contains('imageWhichShouldWiden')
-      })
+      const images = Array.from(document.getElementsByTagName('img')).filter(image =>
+        shouldWidenImage(image) && image.classList.contains('imageWhichShouldWiden'))
       assert.ok(images.length === 2)
     })
 
     it('should indicate four images from the fixture not be widened', () => {
-      const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return !shouldWidenImage(image) && image.classList.contains('imageWhichShouldNotWiden')
-      })
+      const images = Array.from(document.getElementsByTagName('img')).filter(image =>
+        !shouldWidenImage(image) && image.classList.contains('imageWhichShouldNotWiden'))
       assert.ok(images.length === 4)
     })
   })
 
   describe('maybeWidenImage()', () => {
     it('maybeWidenImage always has same return value as shouldWidenImage', () => {
-      const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return shouldWidenImage(image) === maybeWidenImage(image)
-      })
+      const images = Array.from(document.getElementsByTagName('img')).filter(image =>
+        shouldWidenImage(image) === maybeWidenImage(image))
       assert.ok(images.length === 6)
     })
 
@@ -104,9 +101,8 @@ describe('WidenImage', () => {
     })
 
     it('two images from the fixture are actually widened', () => {
-      const images = Array.from(document.getElementsByTagName('img')).filter((image) => {
-        return maybeWidenImage(image) && image.classList.contains('wideImageOverride')
-      })
+      const images = Array.from(document.getElementsByTagName('img')).filter(image =>
+        maybeWidenImage(image) && image.classList.contains('wideImageOverride'))
       assert.ok(images.length === 2)
     })
   })

--- a/test/utilities/FixtureIO.js
+++ b/test/utilities/FixtureIO.js
@@ -7,18 +7,15 @@ import path from 'path'
  * @param  {!string} fileName   Name of file in 'test/fixtures/'
  * @return {?string}            String from `test/fixtures/${fileName}`
  */
-const stringFromFixtureFile = (fileName) => {
-  return fs.readFileSync(path.resolve(__dirname, `../fixtures/${fileName}`), 'utf8')
-}
+const stringFromFixtureFile = fileName =>
+  fs.readFileSync(path.resolve(__dirname, `../fixtures/${fileName}`), 'utf8')
 
 /**
  * Gets Domino document from file in 'test/fixtures/'
  * @param  {!string} fileName   Name of file in 'test/fixtures/'
  * @return {?Document}          Domino document from `test/fixtures/${fileName}`
  */
-const documentFromFixtureFile = (fileName) => {
-  return domino.createDocument(stringFromFixtureFile(fileName))
-}
+const documentFromFixtureFile = fileName => domino.createDocument(stringFromFixtureFile(fileName))
 
 export default {
   stringFromFixtureFile,


### PR DESCRIPTION
Update the ESLint overrides to require parentheses ("()") and curly
braces ("{}") on arrow functions only as needed.