### PR TITLE
Doc: add missing JSDoc return types

### DIFF
--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -7,6 +7,7 @@ import elementUtilities from './ElementUtilities'
  * makes minimal adjustments to ancestors of the image element being widened so the image widening
  * can take effect.
  * @param  {!HTMLElement} el Element whose ancestors will be widened
+ * @return {void}
  */
 const widenAncestors = el => {
   for (let parentElement = el.parentElement;
@@ -25,7 +26,7 @@ const widenAncestors = el => {
 }
 
 /**
- * Some images should not be widended. This method makes that determination.
+ * Some images should not be widened. This method makes that determination.
  * @param  {!HTMLElement} image   The image in question
  * @return {boolean}              Whether 'image' should be widened
  */
@@ -65,6 +66,7 @@ const shouldWidenImage = image => {
 /**
  * Removes barriers to images widening taking effect.
  * @param  {!HTMLElement} image   The image in question
+ * @return {void}
  */
 const makeRoomForImageWidening = image => {
   widenAncestors(image)
@@ -77,6 +79,7 @@ const makeRoomForImageWidening = image => {
 /**
  * Widens the image.
  * @param  {!HTMLElement} image   The image in question
+ * @return {void}
  */
 const widenImage = image => {
   makeRoomForImageWidening(image)

--- a/test/utilities/StyleMocking.js
+++ b/test/utilities/StyleMocking.js
@@ -13,6 +13,7 @@ import assert from 'assert'
  * Sets styles on an element.
  * @param  {!HTMLElement} element   Element
  * @param  {!StylesHash}  styles    Styles to apply to 'element'
+ * @return {void}
  */
 const mockStylesInElement = (element, styles) => {
   for (const [key, value] of Object.entries(styles)) {
@@ -24,6 +25,7 @@ const mockStylesInElement = (element, styles) => {
  * Verifies styles on an element.
  * @param  {!HTMLElement} element   Element
  * @param  {!StylesHash}  styles    Styles to verify on 'element'
+ * @return {void}
  */
 const verifyStylesInElement = (element, styles) => {
   for (const [key, value] of Object.entries(styles)) {
@@ -36,6 +38,7 @@ const verifyStylesInElement = (element, styles) => {
  * Sets styles on each element in an array of elements.
  * @param  {!HTMLElement[]}  elements  Array of elements
  * @param  {!StylesHash}          styles    Styles to apply to each element in 'elements'
+ * @return {void}
  */
 const mockStylesInElements = (elements, styles) => {
   for (const element of elements) {
@@ -47,6 +50,7 @@ const mockStylesInElements = (elements, styles) => {
  * Verifies styles on each element in an array of elements.
  * @param  {!HTMLElement[]}  elements  Array of elements
  * @param  {!StylesHash}          styles    Styles to verify on each element in 'elements'
+ * @return {void}
  */
 const verifyStylesInElements = (elements, styles) => {
   for (const element of elements) {


### PR DESCRIPTION
Specifying that a function has no return value clarifies that it very
likely has side-effects. Add missing `@return {void}` annotations.