### PR TITLE
Fix: package and VS Code test config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,14 +7,12 @@
       "request": "launch",
       "name": "Mocha Tests",
       "cwd": "${workspaceRoot}",
-      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/mocha",
+      "runtimeExecutable": "mocha",
       "runtimeArgs": [
-        "-u",
-        "tdd",
-        "--timeout",
-        "999999",
-        "--colors",
-        "${workspaceRoot}/test"
+        "-u", "tdd",
+        "-t", "999999",
+        "-c",
+        "test/**/*.js"
       ],
       "internalConsoleOptions": "openOnSessionStart"
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:all": "npm run -s lint .",
     "build": "rollup -c",
     "pretest": "npm run -s build",
-    "test": "mocha test/*.js test/**/*.js",
+    "test": "mocha test/**/*.js",
     "clean": "rm -rf build/",
     "preversion": "[ -z \"$(git status -z)\" ]",
     "postversion": "git push --follow-tags origin HEAD && npm publish",


### PR DESCRIPTION
- Remove test/*.js from package configuration. It would be nice to keep
  this in case we ever do put tests at the root but Mocha warns that no
  tests were found so it's better to remove until needed.

- Add test/**/*.js to VS Code configuration.