### PR TITLE
Update: bundle files as a Universal Module Definition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v3.2.0
+- New: update bundle to support AMD, ES, and IIFE / script usage, in addition to CJS
+
 ### v3.1.0
 - New: add RedLinks.hideRedLinks()
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,7 +5,8 @@ import css from 'rollup-plugin-css-porter'
 export default {
   entry: 'src/index.js',
   dest: pkg.main,
-  format: 'cjs',
+  format: 'umd',
+  moduleName: 'pagelib',
   sourceMap: true,
   plugins: [
     css({


### PR DESCRIPTION
This appears to add very little to file size and supports <script>
usage which is helpful for desktop usage and testing.

https://github.com/rollup/rollup/wiki/JavaScript-API#format