### PR TITLE
Chore: permit floating-points without leading or trailing numbers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,6 +7,7 @@ parserOptions:
 rules:
   # Best Practices
   no-else-return: 1
+  no-floating-decimal: 0
 
   # Strict Mode
   strict: [1, never]


### PR DESCRIPTION
From the docs:

  Float values in JavaScript contain a decimal point, and there is no
  requirement that the decimal point be preceded or followed by a
  number. For example, the following are all valid JavaScript numbers:

    var num = .5;
    var num = 2.;
    var num = -.7;

  Although not a syntax error, this format for numbers can make it
  difficult to distinguish between true decimal numbers and the dot
  operator. For this reason, some recommend that you should always
  include a number before and after a decimal point to make it clear the
  intent is to create a decimal number.

Since I don't expect to be able to dot off of primitives, I find I never
mistake `1.0` for an object with a property named `0` and this syntax is
too verbose.

http://eslint.org/docs/rules/no-floating-decimal