### PR TITLE
Fix: add CustomEvent polyfill

### DIFF
--- a/demo/.eslintrc.yml
+++ b/demo/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+  browser: true

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -1,4 +1,5 @@
 import './CollapseTable.css'
+import Polyfill from './Polyfill'
 import elementUtilities from './ElementUtilities'
 
 const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
@@ -229,7 +230,7 @@ const collapseTables = (window, content, pageTitle, isMainPage, infoboxTitle, ot
     // eslint-disable-next-line require-jsdoc, no-loop-func
     const dispatchSectionToggledEvent = collapsed =>
       // eslint-disable-next-line no-undef
-      window.dispatchEvent(new CustomEvent(SECTION_TOGGLED_EVENT_TYPE, { collapsed }))
+      window.dispatchEvent(new Polyfill.CustomEvent(SECTION_TOGGLED_EVENT_TYPE, { collapsed }))
 
     // assign click handler to the collapsed divs
     collapsedHeaderDiv.onclick = () => {

--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -1,21 +1,4 @@
-/**
- * Polyfill function that tells whether a given element matches a selector.
- * @param {!Element} el Element
- * @param {!string} selector Selector to look for
- * @return {!boolean} Whether the element matches the selector
- */
-const matchesSelectorCompat = (el, selector) => {
-  if (el.matches) {
-    return el.matches(selector)
-  }
-  if (el.matchesSelector) {
-    return el.matchesSelector(selector)
-  }
-  if (el.webkitMatchesSelector) {
-    return el.webkitMatchesSelector(selector)
-  }
-  return false
-}
+import Polyfill from './Polyfill'
 
 /**
  * Returns closest ancestor of element which matches selector.
@@ -29,7 +12,7 @@ const matchesSelectorCompat = (el, selector) => {
 const findClosestAncestor = (el, selector) => {
   let parentElement
   for (parentElement = el.parentElement;
-    parentElement && !matchesSelectorCompat(parentElement, selector);
+    parentElement && !Polyfill.matchesSelector(parentElement, selector);
     parentElement = parentElement.parentElement) {
     // Intentionally empty.
   }
@@ -44,7 +27,6 @@ const findClosestAncestor = (el, selector) => {
 const isNestedInTable = el => Boolean(findClosestAncestor(el, 'table'))
 
 export default {
-  matchesSelectorCompat,
   findClosestAncestor,
   isNestedInTable
 }

--- a/src/transform/Polyfill.js
+++ b/src/transform/Polyfill.js
@@ -1,0 +1,31 @@
+/**
+ * Polyfill function that tells whether a given element matches a selector.
+ * @param {!Element} el Element
+ * @param {!string} selector Selector to look for
+ * @return {!boolean} Whether the element matches the selector
+ */
+const matchesSelector = (el, selector) => {
+  if (el.matches) {
+    return el.matches(selector)
+  }
+  if (el.matchesSelector) {
+    return el.matchesSelector(selector)
+  }
+  if (el.webkitMatchesSelector) {
+    return el.webkitMatchesSelector(selector)
+  }
+  return false
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
+// Required by Android API 16 AOSP Nexus S emulator.
+// eslint-disable-next-line no-undef
+const CustomEvent = typeof window !== 'undefined' && window.CustomEvent
+  || function(type, parameters = { bubbles: false, cancelable: false, detail: undefined }) {
+    // eslint-disable-next-line no-undef
+    const event = document.createEvent('CustomEvent')
+    event.initCustomEvent(type, parameters.bubbles, parameters.cancelable, parameters.detail)
+    return event
+  }
+
+export default { matchesSelector, CustomEvent }

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -1,5 +1,6 @@
 import CollapseTable from './CollapseTable'
 import ElementUtilities from './ElementUtilities'
+import Polyfill from './Polyfill'
 import RedLinks from './RedLinks'
 import WidenImage from './WidenImage'
 
@@ -8,6 +9,6 @@ export default {
   RedLinks,
   WidenImage,
   test: {
-    ElementUtilities
+    ElementUtilities, Polyfill
   }
 }

--- a/test/MochaConfiguration.js
+++ b/test/MochaConfiguration.js
@@ -1,0 +1,4 @@
+import domino from 'domino'
+
+global.window = domino.createWindow()
+global.document = global.window.document

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 -r babel-register
+-r test/MochaConfiguration

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -2,9 +2,6 @@ import assert from 'assert'
 import domino from 'domino'
 import pagelib from '../../build/wikimedia-page-library-transform'
 
-// Add expected browser CustomEvent type to environment.
-global.CustomEvent = domino.impl.CustomEvent
-
 describe('CollapseTable', () => {
   describe('getTableHeader()', () => {
     const getTableHeader = pagelib.CollapseTable.test.getTableHeader

--- a/test/transform/ElementUtilities.test.js
+++ b/test/transform/ElementUtilities.test.js
@@ -10,28 +10,6 @@ describe('ElementUtilities', () => {
     document = fixtureIO.documentFromFixtureFile('ElementUtilities.html')
   })
 
-  describe('matchesSelectorCompat()', () => {
-    it('matches()', () => {
-      const element = { matches: () => true }
-      assert.ok(elementUtilities.matchesSelectorCompat(element, 'html'))
-    })
-
-    it('matchesSelector()', () => {
-      const element = { matchesSelector: () => true }
-      assert.ok(elementUtilities.matchesSelectorCompat(element, 'html'))
-    })
-
-    it('webkitMatchesSelector()', () => {
-      const element = { webkitMatchesSelector: () => true }
-      assert.ok(elementUtilities.matchesSelectorCompat(element, 'html'))
-    })
-
-    it('unsupported', () => {
-      const element = {}
-      assert.ok(!elementUtilities.matchesSelectorCompat(element, 'html'))
-    })
-  })
-
   describe('findClosestAncestor()', () => {
     it('doesn\'t consider self', () => {
       const element = document.querySelector('.matching')

--- a/test/transform/Polyfill.test.js
+++ b/test/transform/Polyfill.test.js
@@ -1,0 +1,40 @@
+import assert from 'assert'
+import pagelib from '../../build/wikimedia-page-library-transform'
+
+const Polyfill = pagelib.test.Polyfill
+
+describe('Polyfill', () => {
+  describe('.matchesSelector()', () => {
+    it('.matches()', () => {
+      const element = { matches: () => true }
+      assert.ok(Polyfill.matchesSelector(element, 'html'))
+    })
+
+    it('.matchesSelector()', () => {
+      const element = { matchesSelector: () => true }
+      assert.ok(Polyfill.matchesSelector(element, 'html'))
+    })
+
+    it('.webkitMatchesSelector()', () => {
+      const element = { webkitMatchesSelector: () => true }
+      assert.ok(Polyfill.matchesSelector(element, 'html'))
+    })
+
+    it('unsupported', () => {
+      const element = {}
+      assert.ok(!Polyfill.matchesSelector(element, 'html'))
+    })
+  })
+
+  describe('.CustomEvent', function Test() {
+    beforeEach(() => {
+      this.subject = new Polyfill.CustomEvent('type',
+        { bubbles: 'bubbles', cancelable: 'cancelable', detail: 'detail' })
+    })
+
+    it('.type', () => assert.ok(this.subject.type === 'type'))
+    it('.bubbles', () => assert.ok(this.subject.bubbles === 'bubbles'))
+    it('.cancelable', () => assert.ok(this.subject.cancelable === 'cancelable'))
+    it('.detail', () => assert.ok(this.subject.detail === 'detail'))
+  })
+})


### PR DESCRIPTION
- Add CustomEvent polyfill. This is unavailable on Android API 16 AOSP
  Nexus S emulator.
- Move ElementUtilties.matchesSelectorCompat() to
  Polyfill.matchesSelector(). Anything that has to touch the window as a
  global and requires a compatibility shim should probably go in
  Polyfill. ElementUtilities wasn't a bad place for this function but
  consolidating the hopefully few polyfills we have in one place will
  simplify maintenance.
- Standardize how browser globals are initialized for Mocha tests in
  MochaConfiguration.
- Use browser environment when linting demo directory which will only
  contain webpages.