### PR TITLE
Fix: Browsersync new file monitoring

### DIFF
--- a/.browsersync.config.js
+++ b/.browsersync.config.js
@@ -1,6 +1,7 @@
 // http://www.browsersync.io/docs/options/
 module.exports = {
   files: ['build/*.{css,js}', 'demo/*.{html,css,js,json}'],
+  watchEvents: ['add', 'change'],
   server: {
     baseDir: 'demo',
     directory: true


### PR DESCRIPTION
The default Browsersync configuration only detects modified files.
Update the configuration to detect newly added files too.

https://browsersync.io/docs/options#option-watchEvents