### PR TITLE
Increase collapse table theme selector specificity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.5.9
+- Fix: collapse table theming - increase specificity of collapse table theme selectors
+
 ### v4.5.8
 - Fix: catch failed read more request Errors
 - Update: footer wordmark

--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -89,12 +89,12 @@ div.app_table_container {
   clear: both;
 }
 
-.pagelib-theme-dark div.app_table_container {
+.pagelib-theme-dark .content div.app_table_container {
   box-shadow: none !important;
   background-color: #222 !important;
 }
 
-.pagelib-theme-sepia div.app_table_container {
+.pagelib-theme-sepia .content div.app_table_container {
   box-shadow: none !important;
   background-color: #e1dad1 !important;
 }
@@ -115,7 +115,7 @@ div.app_table_container {
   color: #808080;
 }
 
-.pagelib-theme-dark span.app_span_collapse_text {
+.pagelib-theme-dark .content span.app_span_collapse_text {
   color: #c8ccd1 !important;
 }
 
@@ -132,13 +132,13 @@ div.app_table_container {
   background-size: 16px 16px;
 }
 
-.pagelib-theme-dark div.app_table_collapsed_container,
-.pagelib-theme-dark div.app_table_collapsed_bottom {
+.pagelib-theme-dark .content div.app_table_collapsed_container,
+.pagelib-theme-dark .content div.app_table_collapsed_bottom {
   background-color: #27292d !important;
 }
 
-.pagelib-theme-sepia div.app_table_collapsed_container,
-.pagelib-theme-sepia div.app_table_collapsed_bottom {
+.pagelib-theme-sepia .content div.app_table_collapsed_container,
+.pagelib-theme-sepia .content div.app_table_collapsed_bottom {
   background-color: #f0e6d6 !important;
 }
 


### PR DESCRIPTION
Needed to play nice with more aggressive `baseline` theming approach.

# Before
![screen shot 2017-08-24 at 1 11 48 pm](https://user-images.githubusercontent.com/3143487/29686456-dba469fe-88cd-11e7-90be-9423576a7084.png)


# After
![screen shot 2017-08-24 at 1 11 00 pm](https://user-images.githubusercontent.com/3143487/29686452-d8d8521c-88cd-11e7-86eb-0f28b8ad9889.png)


