### PR TITLE
Fix: some parts of football uniforms not being classified as presuming white background

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.5.10
+- Fix: some parts of football uniforms not being classified as presuming white background
+
 ### v4.5.9
 - Fix: collapse table theming - increase specificity of collapse table theme selectors
 

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -33,6 +33,14 @@ const setTheme = (document, theme) => {
   }
 }
 
+/**
+ * Football template image filename regex.
+ * https://en.wikipedia.org/wiki/Template:Football_kit/pattern_list
+ * @type {RegExp}
+ */
+const footballTemplateImageFilenameRegex =
+  new RegExp('Kit_(body|socks|shorts|right_arm|left_arm)(.*).png$')
+
 /* en > Away colours > 793128975 */
 /* en > Manchester United F.C. > 793244653 */
 /**
@@ -41,15 +49,8 @@ const setTheme = (document, theme) => {
  * @return {!boolean}
  */
 const imagePresumesWhiteBackground = image => {
-  const src = image.src
-  if (src.endsWith('.svg.png')) {
-    return !(
-      src.endsWith('Kit_body.svg.png') ||
-      src.endsWith('Kit_socks_long.svg.png') ||
-      src.endsWith('Kit_shorts.svg.png') ||
-      src.endsWith('Kit_right_arm.svg.png') ||
-      src.endsWith('Kit_left_arm.svg.png')
-    )
+  if (footballTemplateImageFilenameRegex.test(image.src)) {
+    return false
   }
   if (image.classList.contains('mwe-math-fallback-image-inline')) {
     return false


### PR DESCRIPTION
# Before
![screen shot 2017-08-24 at 4 06 21 pm](https://user-images.githubusercontent.com/3143487/29692706-3ff9519a-88e6-11e7-930f-74b3c53616a8.png)


# After
(notice some green parts have appeared in the top row)
![after](https://user-images.githubusercontent.com/3143487/29692705-3fcbdbc0-88e6-11e7-910a-249c1bc1c762.png)
