### PR TITLE
Fix: override inline heights in Parsoid HTML

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.7.1
+- Fix: override image ancestor inline heights (found in Parsoid HTML) with `height: 'auto'`
+
 ### v4.7.0
 - New: add a footer link to view the article in browser
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikimedia-page-library",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Cross-platform JavaScript and CSS library for Wikimedia apps",
   "keywords": [
     "Wikipedia",

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -16,6 +16,9 @@ const widenAncestors = el => {
     if (parentElement.style.width) {
       parentElement.style.width = '100%'
     }
+    if (parentElement.style.height) {
+      parentElement.style.height = 'auto'
+    }
     if (parentElement.style.maxWidth) {
       parentElement.style.maxWidth = '100%'
     }


### PR DESCRIPTION
Parsoid HTML image ancestors, unlike in MediaWiki HTML, often specify
height attributes.  These cramp widened images so that they overlap
their captions and one another (https://phabricator.wikimedia.org/T176753). 

Overriding with `height: 'auto'` fixes this issue.