### PR TITLE
Remove recursion from table collapse transform

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.7.3
+- Fix: remove unneeded recursion in table collapse transform
+
 ### v4.7.2
 - Fix: add missing talk page menu type
 

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -15,21 +15,19 @@ const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
 const getTableHeader = (element, pageTitle) => {
   const thArray = []
   const headers = Polyfill.querySelectorAll(element, 'th')
-  if (headers) {
-    for (let i = 0; i < headers.length; ++i) {
-      const header = headers[i]
-      const anchors = Polyfill.querySelectorAll(header, 'a')
-      if (anchors.length < 3) {
-        // Also ignore it if it's identical to the page title.
-        if ((header.textContent && header.textContent.length) > 0
-          && header.textContent !== pageTitle && header.innerHTML !== pageTitle) {
-          thArray.push(header.textContent)
-        }
+  for (let i = 0; i < headers.length; ++i) {
+    const header = headers[i]
+    const anchors = Polyfill.querySelectorAll(header, 'a')
+    if (anchors.length < 3) {
+      // Also ignore it if it's identical to the page title.
+      if ((header.textContent && header.textContent.length) > 0
+        && header.textContent !== pageTitle && header.innerHTML !== pageTitle) {
+        thArray.push(header.textContent)
       }
-      if (thArray.length === 2) {
-        // 'newCaption' only ever uses the first 2 items.
-        break
-      }
+    }
+    if (thArray.length === 2) {
+      // 'newCaption' only ever uses the first 2 items.
+      break
     }
   }
   return thArray

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -16,7 +16,8 @@ const getTableHeader = (element, pageTitle) => {
   const thArray = []
   const headers = Polyfill.querySelectorAll(element, 'th')
   if (headers) {
-    headers.forEach(header => {
+    for (let i = 0; i < headers.length; ++i) {
+      const header = headers[i]
       const anchors = Polyfill.querySelectorAll(header, 'a')
       if (anchors.length < 3) {
         // Also ignore it if it's identical to the page title.
@@ -25,7 +26,11 @@ const getTableHeader = (element, pageTitle) => {
           thArray.push(header.textContent)
         }
       }
-    })
+      if (thArray.length === 2) {
+        // 'newCaption' only ever uses the first 2 items.
+        break
+      }
+    }
   }
   return thArray
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -13,48 +13,20 @@ const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
  * @return {!Array<string>}
  */
 const getTableHeader = (element, pageTitle) => {
-  let thArray = []
-
-  if (!element.children) {
-    return thArray
-  }
-
-  for (let i = 0; i < element.children.length; i++) {
-    const el = element.children[i]
-
-    if (el.tagName === 'TH') {
-      // ok, we have a TH element!
-      // However, if it contains more than two links, then ignore it, because
-      // it will probably appear weird when rendered as plain text.
-      const aNodes = el.querySelectorAll('a')
-      // todo: these conditionals are very confusing. Rewrite by extracting a
-      //       method or simplify.
-      if (aNodes.length < 3) {
-        // todo: remove nonstandard Element.innerText usage
+  const thArray = []
+  const headers = Polyfill.querySelectorAll(element, 'th')
+  if (headers) {
+    headers.forEach(header => {
+      const anchors = Polyfill.querySelectorAll(header, 'a')
+      if (anchors.length < 3) {
         // Also ignore it if it's identical to the page title.
-        if ((el.innerText && el.innerText.length || el.textContent.length) > 0
-                && el.innerText !== pageTitle && el.textContent !== pageTitle
-                && el.innerHTML !== pageTitle) {
-          thArray.push(el.innerText || el.textContent)
+        if ((header.textContent && header.textContent.length) > 0
+          && header.textContent !== pageTitle && header.innerHTML !== pageTitle) {
+          thArray.push(header.textContent)
         }
       }
-    }
-
-    // if it's a table within a table, don't worry about it
-    if (el.tagName === 'TABLE') {
-      continue
-    }
-
-    // todo: why do we need to recurse?
-    // recurse into children of this element
-    const ret = getTableHeader(el, pageTitle)
-
-    // did we get a list of TH from this child?
-    if (ret.length > 0) {
-      thArray = thArray.concat(ret)
-    }
+    })
   }
-
   return thArray
 }
 

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -45,10 +45,10 @@ describe('CollapseTable', () => {
             assert.deepEqual(actual, [])
           })
 
-          it('and no page title, shouldn\'t find header', () => {
+          it('and no page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')
             const actual = getTableHeader(doc.querySelector('table'))
-            assert.deepEqual(actual, [])
+            assert.deepEqual(actual, ['text'])
           })
         })
       })
@@ -439,10 +439,10 @@ describe('CollapseTable', () => {
           this.window.document.querySelector('table').parentNode.children[2].click()
         })
 
-        it('table header is unused', function Test() {
+        it('table header is used', function Test() {
           collapseTables(this.window, this.window.document)
           const header = this.window.document.querySelector('.pagelib_collapse_table_expanded')
-          assert.ok(!header)
+          assert.ok(header)
         })
 
         it('and page title is specified, table header is used', function Test() {


### PR DESCRIPTION
I'd definitely like to further simplify and cleanup this XF, but for now I kept this PR diff minimal.

According to Safari Web Inspector Timelines recording, with this PR, on my iPhone 6s the `collapseTables` transform on `enwiki > Barack Obama` drops from 200 - 220ms to 2 - 8ms :)