### PR TITLE
Ensure 'display: block' for widened image ancestors

### DIFF
--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -25,6 +25,12 @@ const widenAncestors = el => {
     if (parentElement.style.float) {
       parentElement.style.float = 'none'
     }
+    // Override 'display: flex' when present so that the image can fully widen. This seems to be an
+    // issue only on Android and with mobileview HTML. See, e.g., the first image in:
+    // https://en.m.wikipedia.org/wiki/Picasso%27s_Blue_Period?oldid=806483472
+    if (parentElement.style.display) {
+      parentElement.style.display = 'block'
+    }
   }
 }
 


### PR DESCRIPTION
Fixes another image widening bug in the Android app. Non-mw-gallery
images, in HTML loaded from action=mobileview, may have a thumbinner div
ancestor with a 'display: flex' or 'display: -webkit-flex' attribute.
Either of these prevents the image from widening as intended. Setting
'display: block' in the widenImage transform in these instances should
fix it.

Phab: https://phabricator.wikimedia.org/T163738 (see Steps to reproduce >
Mobileview)