### PR TITLE
Fix: lazy load race condition in demos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.7.8
+- Fix: lazy loading race condition in demos
+
 ### v4.7.7
 - New: add "black" theme, which features a fully-black background to optimize for AMOLED displays.
 

--- a/demo/LazyLoadTransform.html
+++ b/demo/LazyLoadTransform.html
@@ -28,7 +28,7 @@
 
       const div = lazyDocument.createElement('div')
       for (const data of DemoImageData) {
-        const image = data.newImage(document)
+        const image = data.newImage(lazyDocument)
         pagelib.WidenImage.maybeWidenImage(image)
         div.appendChild(image)
       }

--- a/demo/LazyLoadTransformer.html
+++ b/demo/LazyLoadTransformer.html
@@ -27,7 +27,7 @@
 
       const div = lazyDocument.createElement('div')
       for (const data of DemoImageData) {
-        const image = data.newImage(document)
+        const image = data.newImage(lazyDocument)
         div.appendChild(image)
       }
 


### PR DESCRIPTION
Use the lazy document when creating new images to avoid a race condition
with the browser for replacing the images with placeholders. Images
created in the lazy document will not be loaded.