### PR TITLE
Design tweak for collapsing tables in black theme.

### DIFF
--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -88,10 +88,14 @@ div.pagelib_collapse_table_container {
   clear: both;
 }
 
-.pagelib_theme_dark .content div.pagelib_collapse_table_container,
-.pagelib_theme_black .content div.pagelib_collapse_table_container {
+.pagelib_theme_dark .content div.pagelib_collapse_table_container {
   box-shadow: none !important;
   background-color: #222 !important;
+}
+
+.pagelib_theme_black .content div.pagelib_collapse_table_container {
+  box-shadow: none !important;
+  border: 1px solid #43464a;
 }
 
 .pagelib_theme_sepia .content div.pagelib_collapse_table_container {


### PR DESCRIPTION
The collapsible tables have a black background which is the same as the
article backround, which is making them hard to discern within the page.

This adds a thin gray border around collapsible tables, per design
discussions, to make the table more discoverable in black mode.