### PR TITLE
Fix image widening with lazy load on iOS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### v4.7.8
 - Fix: lazy loading race condition in demos
+- Fix: image widening not always working on iOS when used with lazy loading
 
 ### v4.7.7
 - New: add "black" theme, which features a fully-black background to optimize for AMOLED displays.

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -39,11 +39,10 @@ const updateStyleValue = (style, key, value) => {
  * @return {void}
  */
 const updateExistingStyleValue = (style, key, value) => {
-  const existingValue = style[key]
-  if (!existingValue) {
-    return
+  const valueExists = Boolean(style[key])
+  if (valueExists) {
+    updateStyleValue(style, key, value)
   }
-  updateStyleValue(style, key, value)
 }
 
 /**
@@ -162,6 +161,7 @@ export default {
   maybeWidenImage,
   test: {
     shouldWidenImage,
+    updateExistingStyleValue,
     widenAncestors
   }
 }

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -46,15 +46,15 @@ const updateExistingStyleValue = (style, key, value) => {
 }
 
 /**
- * Array of arrays of image widening CSS key/value pairs.
- * @type {Array}
+ * Image widening CSS key/value pairs.
+ * @type {Object}
  */
-const styleWideningKeysAndValues = [
-  ['width', '100%'],
-  ['height', 'auto'],
-  ['maxWidth', '100%'],
-  ['float', 'none']
-]
+const styleWideningKeysAndValues = {
+  width: '100%',
+  height: 'auto',
+  maxWidth: '100%',
+  float: 'none'
+}
 
 /**
  * Perform widening on an element. Certain style properties are updated, but only if existing values
@@ -63,8 +63,8 @@ const styleWideningKeysAndValues = [
  * @return {void}
  */
 const widenElementByUpdatingExistingStyles = element => {
-  styleWideningKeysAndValues
-    .forEach(keyAndValue => updateExistingStyleValue(element.style, ...keyAndValue))
+  Object.keys(styleWideningKeysAndValues)
+    .forEach(key => updateExistingStyleValue(element.style, key, styleWideningKeysAndValues[key]))
 }
 
 /**
@@ -73,8 +73,8 @@ const widenElementByUpdatingExistingStyles = element => {
  * @return {void}
  */
 const widenElementByUpdatingStyles = element => {
-  styleWideningKeysAndValues
-    .forEach(keyAndValue => updateStyleValue(element.style, ...keyAndValue))
+  Object.keys(styleWideningKeysAndValues)
+    .forEach(key => updateStyleValue(element.style, key, styleWideningKeysAndValues[key]))
 }
 
 /**

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -22,7 +22,7 @@ const ancestorsToWiden = element => {
 
 /**
  * Sets style value.
- * @param {CSSStyleDeclaration} style
+ * @param {!CSSStyleDeclaration} style
  * @param {!string} key
  * @param {*} value
  * @return {void}

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -160,6 +160,7 @@ const maybeWidenImage = image => {
 export default {
   maybeWidenImage,
   test: {
+    ancestorsToWiden,
     shouldWidenImage,
     updateExistingStyleValue,
     widenAncestors

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -163,6 +163,8 @@ export default {
     ancestorsToWiden,
     shouldWidenImage,
     updateExistingStyleValue,
-    widenAncestors
+    widenAncestors,
+    widenElementByUpdatingExistingStyles,
+    widenElementByUpdatingStyles
   }
 }

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -69,6 +69,16 @@ const widenElementByUpdatingExistingStyles = element => {
 }
 
 /**
+ * Perform widening on an element.
+ * @param  {!HTMLElement} element
+ * @return {void}
+ */
+const widenElementByUpdatingStyles = element => {
+  styleWideningKeysAndValues
+    .forEach(keyAndValue => updateStyleValue(element.style, ...keyAndValue))
+}
+
+/**
  * To widen an image element a css class called 'pagelib_widen_image_override' is applied to the
  * image element, however, ancestors of the image element can prevent the widening from taking
  * effect. This method makes minimal adjustments to ancestors of the image element being widened so
@@ -78,6 +88,13 @@ const widenElementByUpdatingExistingStyles = element => {
  */
 const widenAncestors = element => {
   ancestorsToWiden(element).forEach(widenElementByUpdatingExistingStyles)
+
+  // Without forcing widening on the parent anchor, lazy image loading placeholders
+  // aren't correctly widened on iOS for some reason.
+  const parentAnchor = elementUtilities.findClosestAncestor(element, 'a.image')
+  if (parentAnchor) {
+    widenElementByUpdatingStyles(parentAnchor)
+  }
 }
 
 /**

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -2,30 +2,82 @@ import './WidenImage.css'
 import elementUtilities from './ElementUtilities'
 
 /**
+ * Gets array of ancestors of element which need widening.
+ * @param  {!HTMLElement} element
+ * @return {!Array.<HTMLElement>} Zero length array is returned if no elements should be widened.
+ */
+const ancestorsToWiden = element => {
+  const widenThese = []
+  let el = element
+  while (el.parentNode) {
+    el = el.parentNode
+    // No need to walk above 'content_block'.
+    if (el.classList.contains('content_block')) {
+      break
+    }
+    widenThese.push(el)
+  }
+  return widenThese
+}
+
+/**
+ * Sets style value.
+ * @param {HTMLElement.style} style
+ * @param {!string} key
+ * @param {*} value
+ * @return {void}
+ */
+const updateStyleValue = (style, key, value) => {
+  style[key] = value
+}
+
+/**
+ * Sets style value only if value for given key already exists.
+ * @param {HTMLElement.style} style
+ * @param {!string} key
+ * @param {*} value
+ * @return {void}
+ */
+const updateExistingStyleValue = (style, key, value) => {
+  const existingValue = style[key]
+  if (!existingValue) {
+    return
+  }
+  updateStyleValue(style, key, value)
+}
+
+/**
+ * Array of arrays of image widening CSS key/value pairs.
+ * @type {Array}
+ */
+const styleWideningKeysAndValues = [
+  ['width', '100%'],
+  ['height', 'auto'],
+  ['maxWidth', '100%'],
+  ['float', 'none']
+]
+
+/**
+ * Perform widening on an element. Certain style properties are updated, but only if existing values
+ * for these properties already exist.
+ * @param  {!HTMLElement} element
+ * @return {void}
+ */
+const widenElementByUpdatingExistingStyles = element => {
+  styleWideningKeysAndValues
+    .forEach(keyAndValue => updateExistingStyleValue(element.style, ...keyAndValue))
+}
+
+/**
  * To widen an image element a css class called 'pagelib_widen_image_override' is applied to the
  * image element, however, ancestors of the image element can prevent the widening from taking
  * effect. This method makes minimal adjustments to ancestors of the image element being widened so
  * the image widening can take effect.
- * @param  {!HTMLElement} el Element whose ancestors will be widened
+ * @param  {!HTMLElement} element Element whose ancestors will be widened
  * @return {void}
  */
-const widenAncestors = el => {
-  for (let parentElement = el.parentElement;
-    parentElement && !parentElement.classList.contains('content_block');
-    parentElement = parentElement.parentElement) {
-    if (parentElement.style.width) {
-      parentElement.style.width = '100%'
-    }
-    if (parentElement.style.height) {
-      parentElement.style.height = 'auto'
-    }
-    if (parentElement.style.maxWidth) {
-      parentElement.style.maxWidth = '100%'
-    }
-    if (parentElement.style.float) {
-      parentElement.style.float = 'none'
-    }
-  }
+const widenAncestors = element => {
+  ancestorsToWiden(element).forEach(widenElementByUpdatingExistingStyles)
 }
 
 /**

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -22,7 +22,7 @@ const ancestorsToWiden = element => {
 
 /**
  * Sets style value.
- * @param {HTMLElement.style} style
+ * @param {CSSStyleDeclaration} style
  * @param {!string} key
  * @param {*} value
  * @return {void}
@@ -33,7 +33,7 @@ const updateStyleValue = (style, key, value) => {
 
 /**
  * Sets style value only if value for given key already exists.
- * @param {HTMLElement.style} style
+ * @param {CSSStyleDeclaration} style
  * @param {!string} key
  * @param {*} value
  * @return {void}

--- a/test/fixtures/WidenImage.html
+++ b/test/fixtures/WidenImage.html
@@ -17,9 +17,9 @@
       </tr>
     </table>
     <img class='imageWhichShouldWiden' id='imageWithWidthAndHeight' width='100' height='100'>
-    <div class='widthConstrainedAncestor'>
-      <div class='widthConstrainedAncestor'>
-        <div class='widthConstrainedAncestor'>
+    <div class='widthConstrainedAncestor' id=widthConstrainedAncestor3>
+      <div class='widthConstrainedAncestor' id=widthConstrainedAncestor2>
+        <div class='widthConstrainedAncestor' id=widthConstrainedAncestor1>
           <img class='imageWhichShouldWiden' id='imageInWidthConstrainedAncestors'>
         </div>
       </div>

--- a/test/transform/WidenImage.test.js
+++ b/test/transform/WidenImage.test.js
@@ -8,6 +8,7 @@ const maybeWidenImage = pagelib.WidenImage.maybeWidenImage
 const shouldWidenImage = pagelib.WidenImage.test.shouldWidenImage
 const widenAncestors = pagelib.WidenImage.test.widenAncestors
 const updateExistingStyleValue = pagelib.WidenImage.test.updateExistingStyleValue
+const ancestorsToWiden = pagelib.WidenImage.test.ancestorsToWiden
 
 let document
 
@@ -127,6 +128,17 @@ describe('WidenImage', () => {
       assert.ok(element.style.width === undefined)
       assert.ok(element.style.float === undefined)
       assert.ok(element.style.maxWidth === undefined)
+    })
+  })
+
+  describe('ancestorsToWiden()', () => {
+    it('ancestors which need widening for image inside width constrained elements', () => {
+      const image = document.getElementById('imageInWidthConstrainedAncestors')
+      const ancestors = ancestorsToWiden(image)
+      assert.ok(ancestors.length === 3)
+      assert.ok(ancestors[0].id === 'widthConstrainedAncestor1')
+      assert.ok(ancestors[1].id === 'widthConstrainedAncestor2')
+      assert.ok(ancestors[2].id === 'widthConstrainedAncestor3')
     })
   })
 })

--- a/test/transform/WidenImage.test.js
+++ b/test/transform/WidenImage.test.js
@@ -9,6 +9,9 @@ const shouldWidenImage = pagelib.WidenImage.test.shouldWidenImage
 const widenAncestors = pagelib.WidenImage.test.widenAncestors
 const updateExistingStyleValue = pagelib.WidenImage.test.updateExistingStyleValue
 const ancestorsToWiden = pagelib.WidenImage.test.ancestorsToWiden
+const widenElementByUpdatingStyles = pagelib.WidenImage.test.widenElementByUpdatingStyles
+const widenElementByUpdatingExistingStyles =
+  pagelib.WidenImage.test.widenElementByUpdatingExistingStyles
 
 let document
 
@@ -139,6 +142,44 @@ describe('WidenImage', () => {
       assert.ok(ancestors[0].id === 'widthConstrainedAncestor1')
       assert.ok(ancestors[1].id === 'widthConstrainedAncestor2')
       assert.ok(ancestors[2].id === 'widthConstrainedAncestor3')
+    })
+  })
+
+  describe('widenElementByUpdatingStyles()', () => {
+    it('styles updated whether they exist or not', () => {
+      const element = document.querySelector('#widthConstrainedAncestor1')
+      assert.ok(element.style.width === undefined)
+      assert.ok(element.style.height === undefined)
+      styleMocking.mockStylesInElement(element, {
+        maxWidth: '50%',
+        float: 'right'
+      })
+      widenElementByUpdatingStyles(element)
+      styleMocking.verifyStylesInElement(element, {
+        width: '100%',
+        height: 'auto',
+        maxWidth: '100%',
+        float: 'none'
+      })
+    })
+  })
+
+  describe('widenElementByUpdatingExistingStyles()', () => {
+    it('only existing styles updated', () => {
+      const element = document.querySelector('#widthConstrainedAncestor1')
+      assert.ok(element.style.width === undefined)
+      assert.ok(element.style.height === undefined)
+      styleMocking.mockStylesInElement(element, {
+        maxWidth: '50%',
+        float: 'right'
+      })
+      widenElementByUpdatingExistingStyles(element)
+      styleMocking.verifyStylesInElement(element, {
+        width: undefined,
+        height: undefined,
+        maxWidth: '100%',
+        float: 'none'
+      })
     })
   })
 })


### PR DESCRIPTION
On iOS if we used the image widening transform, then used the lazy image loading transform, the image placeholders were not correctly widened. Turned out to be related to image widening not also widening the image anchor, though I'm not quite sure why this only manifests itself on iOS webkit.

[Screenshots and discussion](https://github.com/wikimedia/wikipedia-ios/pull/1971#discussion_r155354570).

https://phabricator.wikimedia.org/T175323