### PR TITLE
Fix title encoding when updating Read More save buttons.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v4.7.9
+- Fix: encoding of titles when updating Read More save buttons
+
 ### v4.7.8
 - Fix: lazy loading race condition in demos
 - Fix: image widening not always working on iOS when used with lazy loading

--- a/src/transform/FooterReadMore.js
+++ b/src/transform/FooterReadMore.js
@@ -288,7 +288,7 @@ const updateSaveButtonBookmarkIcon = (button, isSaved) => {
  * @return {void}
 */
 const updateSaveButtonForTitle = (title, text, isSaved, document) => {
-  const saveButton = document.getElementById(`${SAVE_BUTTON_ID_PREFIX}${title}`)
+  const saveButton = document.getElementById(`${SAVE_BUTTON_ID_PREFIX}${encodeURI(title)}`)
   saveButton.innerText = text
   saveButton.title = text
   updateSaveButtonBookmarkIcon(saveButton, isSaved)


### PR DESCRIPTION
https://phabricator.wikimedia.org/T182631

Noticed save button was missing on read more result for `Raphael_Assunção` on `enwiki > Aljamain Sterling`.