### PR TITLE
Fix for certain pages not getting sections appended

### DIFF
--- a/src/transform/FooterReadMore.js
+++ b/src/transform/FooterReadMore.js
@@ -289,6 +289,9 @@ const updateSaveButtonBookmarkIcon = (button, isSaved) => {
 */
 const updateSaveButtonForTitle = (title, text, isSaved, document) => {
   const saveButton = document.getElementById(`${SAVE_BUTTON_ID_PREFIX}${encodeURI(title)}`)
+  if (!saveButton) {
+    return
+  }
   saveButton.innerText = text
   saveButton.title = text
   updateSaveButtonBookmarkIcon(saveButton, isSaved)

--- a/src/transform/FooterReadMore.js
+++ b/src/transform/FooterReadMore.js
@@ -289,9 +289,6 @@ const updateSaveButtonBookmarkIcon = (button, isSaved) => {
 */
 const updateSaveButtonForTitle = (title, text, isSaved, document) => {
   const saveButton = document.getElementById(`${SAVE_BUTTON_ID_PREFIX}${encodeURI(title)}`)
-  if (!saveButton) {
-    return
-  }
   saveButton.innerText = text
   saveButton.title = text
   updateSaveButtonBookmarkIcon(saveButton, isSaved)

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -12,7 +12,7 @@ const ancestorsToWiden = element => {
   while (el.parentNode) {
     el = el.parentNode
     // No need to walk above 'content_block'.
-    if (el.classList && el.classList.contains('content_block')) {
+    if (el.classList.contains('content_block')) {
       break
     }
     widenThese.push(el)
@@ -28,9 +28,6 @@ const ancestorsToWiden = element => {
  * @return {void}
  */
 const updateStyleValue = (style, key, value) => {
-  if (!style || !key) {
-    return
-  }
   style[key] = value
 }
 
@@ -42,7 +39,7 @@ const updateStyleValue = (style, key, value) => {
  * @return {void}
  */
 const updateExistingStyleValue = (style, key, value) => {
-  const valueExists = style && key && Boolean(style[key])
+  const valueExists = Boolean(style[key])
   if (valueExists) {
     updateStyleValue(style, key, value)
   }

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -9,8 +9,8 @@ import elementUtilities from './ElementUtilities'
 const ancestorsToWiden = element => {
   const widenThese = []
   let el = element
-  while (el.parentNode) {
-    el = el.parentNode
+  while (el.parentElement) {
+    el = el.parentElement
     // No need to walk above 'content_block'.
     if (el.classList.contains('content_block')) {
       break

--- a/src/transform/WidenImage.js
+++ b/src/transform/WidenImage.js
@@ -12,7 +12,7 @@ const ancestorsToWiden = element => {
   while (el.parentNode) {
     el = el.parentNode
     // No need to walk above 'content_block'.
-    if (el.classList.contains('content_block')) {
+    if (el.classList && el.classList.contains('content_block')) {
       break
     }
     widenThese.push(el)
@@ -28,6 +28,9 @@ const ancestorsToWiden = element => {
  * @return {void}
  */
 const updateStyleValue = (style, key, value) => {
+  if (!style || !key) {
+    return
+  }
   style[key] = value
 }
 
@@ -39,7 +42,7 @@ const updateStyleValue = (style, key, value) => {
  * @return {void}
  */
 const updateExistingStyleValue = (style, key, value) => {
-  const valueExists = Boolean(style[key])
+  const valueExists = style && key && Boolean(style[key])
   if (valueExists) {
     updateStyleValue(style, key, value)
   }


### PR DESCRIPTION
On iOS, links from the sign post page weren't loading at all. 

Repro steps:

- In Safari, search for Wikipedia Signpost
- Tap the link for the sign post page (https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/Single/2017-12-18)
- Tap through to any of the links on the page

It's entirely possible these fixes are misguided, I just looked in the JS console and added protections around where there were errors for undefined values. After fixing these issues, the links from the signpost page load as expected.