### PR TITLE
Update: bump Babel iOS target version to 10.3 and Android to 4.4

### DIFF
--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["env", {
-      "targets": { "android": "4.1", "ios": "9.3" },
+      "targets": { "android": "4.1", "ios": "10.3" },
       "plugins": [ "external-helpers" ],
       "modules": false
     }]

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     ["env", {
-      "targets": { "android": "4.1", "ios": "10.3" },
+      "targets": { "android": "4.4", "ios": "10.3" },
       "plugins": [ "external-helpers" ],
       "modules": false
     }]


### PR DESCRIPTION
Is 4.1 still accurate for Android?