### PR TITLE
Fix: table headers shouldn't include coordinates, reference links

### DIFF
--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -168,7 +168,7 @@ const newCaption = (title, headerText) => {
 
 /**
  * @param {!Window} window
- * @param {!Element} content
+ * @param {!Document} document
  * @param {?string} pageTitle
  * @param {?boolean} isMainPage
  * @param {?boolean} isInitiallyCollapsed
@@ -178,11 +178,11 @@ const newCaption = (title, headerText) => {
  * @param {?FooterDivClickCallback} footerDivClickCallback
  * @return {void}
  */
-const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollapsed,
+const adjustTables = (window, document, pageTitle, isMainPage, isInitiallyCollapsed,
   infoboxTitle, otherTitle, footerTitle, footerDivClickCallback) => {
   if (isMainPage) { return }
 
-  const tables = content.querySelectorAll('table')
+  const tables = document.querySelectorAll('table')
   for (let i = 0; i < tables.length; ++i) {
     const table = tables[i]
 
@@ -192,7 +192,7 @@ const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollaps
     }
 
     // todo: this is actually an array
-    const headerText = getTableHeader(content, table, pageTitle)
+    const headerText = getTableHeader(document, table, pageTitle)
     if (!headerText.length && !isInfobox(table)) {
       continue
     }
@@ -200,7 +200,7 @@ const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollaps
 
     // create the container div that will contain both the original table
     // and the collapsed version.
-    const containerDiv = window.document.createElement('div')
+    const containerDiv = document.createElement('div')
     containerDiv.className = 'pagelib_collapse_table_container'
     table.parentNode.insertBefore(containerDiv, table)
     table.parentNode.removeChild(table)
@@ -210,10 +210,10 @@ const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollaps
     table.style.marginTop = '0px'
     table.style.marginBottom = '0px'
 
-    const collapsedHeaderDiv = newCollapsedHeaderDiv(window.document, caption)
+    const collapsedHeaderDiv = newCollapsedHeaderDiv(document, caption)
     collapsedHeaderDiv.style.display = 'block'
 
-    const collapsedFooterDiv = newCollapsedFooterDiv(window.document, footerTitle)
+    const collapsedFooterDiv = newCollapsedFooterDiv(document, footerTitle)
     collapsedFooterDiv.style.display = 'none'
 
     // add our stuff to the container
@@ -248,7 +248,7 @@ const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollaps
 
 /**
  * @param {!Window} window
- * @param {!Element} content
+ * @param {!Document} document
  * @param {?string} pageTitle
  * @param {?boolean} isMainPage
  * @param {?string} infoboxTitle
@@ -257,9 +257,9 @@ const adjustTables = (window, content, pageTitle, isMainPage, isInitiallyCollaps
  * @param {?FooterDivClickCallback} footerDivClickCallback
  * @return {void}
  */
-const collapseTables = (window, content, pageTitle, isMainPage, infoboxTitle, otherTitle,
+const collapseTables = (window, document, pageTitle, isMainPage, infoboxTitle, otherTitle,
   footerTitle, footerDivClickCallback) => {
-  adjustTables(window, content, pageTitle, isMainPage, true, infoboxTitle, otherTitle,
+  adjustTables(window, document, pageTitle, isMainPage, true, infoboxTitle, otherTitle,
     footerTitle, footerDivClickCallback)
 }
 

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -22,6 +22,27 @@ const isHeaderEligible =
 const isHeaderTextEligible = headerText => headerText && headerText.trim().length > 0
 
 /**
+ * Is node's textContent too similar to pageTitle. Checks if the node's textContent is found at the
+ * beginning of pageTitle, but the comparison ignores whitespace, punctuation and dashes, etc.
+ * @param  {!node} node
+ * @param  {!string} pageTitle
+ * @return {[type]}
+ */
+const nodeTextContentSimilarToPageTitle = (node, pageTitle) => {
+  const alphaNumericTitle = pageTitle.replace(/[\W_]+/g, '')
+  const alphaNumericText = node.textContent.replace(/[\W_]+/g, '')
+  return alphaNumericTitle.indexOf(alphaNumericText) === 0
+}
+
+/**
+ * Determines if a node is an element or text node.
+ * @param  {!node} node
+ * @return {!boolean}
+ */
+const nodeTypeIsElementOrText = node =>
+  node.nodeType === ELEMENT_NODE || node.nodeType === TEXT_NODE
+
+/**
  * Extracts any header text determined to be eligible.
  * @param {!Document} document
  * @param {!Element} header
@@ -32,7 +53,6 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
   if (!isHeaderEligible(header)) {
     return null
   }
-
   // Clone header into fragment. This is done so we can remove some elements we don't want
   // represented when "textContent" is used. Because we've cloned the header into a fragment, we are
   // free to strip out anything we want without worrying about affecting the visible document.
@@ -44,19 +64,9 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
     .forEach(el => el.remove())
 
   if (pageTitle) {
-    const nodeTextContentStartsWithPageTitle = node => { // eslint-disable-line require-jsdoc
-      // Make the comparison ignore whitespace, punctuation and dashes, etc.
-      const alphaNumericTitle = pageTitle.replace(/[\W_]+/g, '')
-      const alphaNumericText = node.textContent.replace(/[\W_]+/g, '')
-      return alphaNumericTitle.indexOf(alphaNumericText) === 0
-    }
-    // eslint-disable-next-line require-jsdoc
-    const nodeTypeIsElementOrText = node =>
-      node.nodeType === ELEMENT_NODE || node.nodeType === TEXT_NODE
-
     Array.prototype.slice.call(fragmentHeader.childNodes)
       .filter(nodeTypeIsElementOrText)
-      .filter(nodeTextContentStartsWithPageTitle)
+      .filter(node => nodeTextContentSimilarToPageTitle(node, pageTitle))
       .forEach(node => node.remove())
   }
 
@@ -356,6 +366,7 @@ export default {
     isInfobox,
     newCollapsedHeaderDiv,
     newCollapsedFooterDiv,
-    newCaptionFragment
+    newCaptionFragment,
+    nodeTextContentSimilarToPageTitle
   }
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -68,7 +68,7 @@ const nodeTypeIsElementOrText = node =>
  * @param  {!string} string
  * @return {!string}
  */
-const stringWithNormalizedSpaces = string => string.trim().replace(/\s/g, ' ')
+const stringWithNormalizedWhitespace = string => string.trim().replace(/\s/g, ' ')
 
 /**
  * Extracts any header text determined to be eligible.
@@ -100,7 +100,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
 
   const headerText = fragmentHeader.textContent
   if (isHeaderTextEligible(headerText)) {
-    return stringWithNormalizedSpaces(headerText)
+    return stringWithNormalizedWhitespace(headerText)
   }
   return null
 }
@@ -422,6 +422,6 @@ export default {
     newCollapsedFooterDiv,
     newCaptionFragment,
     isNodeTextContentSimilarToPageTitle,
-    stringWithNormalizedSpaces
+    stringWithNormalizedWhitespace
   }
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -5,6 +5,13 @@ import elementUtilities from './ElementUtilities'
 const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
 
 /**
+ * Determine if we want to extract text from this header.
+ * @param {!Element} header
+ * @return {!boolean}
+ */
+const isHeaderEligible = header => Polyfill.querySelectorAll(header, 'a').length < 3
+
+/**
  * Extracts header text.
  * @param {!Document} document
  * @param {!Element} header
@@ -35,8 +42,7 @@ const getTableHeaderTextArray = (document, element, pageTitle) => {
   const headers = Polyfill.querySelectorAll(element, 'th')
   for (let i = 0; i < headers.length; ++i) {
     const header = headers[i]
-    const anchors = Polyfill.querySelectorAll(header, 'a')
-    if (anchors.length < 3) {
+    if (isHeaderEligible(header)) {
       const headerText = extractHeaderText(document, header)
       // Also ignore it if it's identical to the page title.
       if ((headerText && headerText.length) > 0

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -88,7 +88,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
   fragment.appendChild(header.cloneNode(true))
   const fragmentHeader = fragment.querySelector('th')
 
-  Polyfill.querySelectorAll(fragmentHeader, '.geo, .coordinates, sup.reference, li')
+  Polyfill.querySelectorAll(fragmentHeader, '.geo, .coordinates, sup.reference, ol, ul')
     .forEach(el => el.remove())
 
   if (pageTitle) {

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -13,7 +13,7 @@ const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
  *                            contents of the header exactly, it will be omitted.
  * @return {!Array<string>}
  */
-const getTableHeader = (document, element, pageTitle) => {
+const getTableHeaderTextArray = (document, element, pageTitle) => {
   const thArray = []
   const headers = Polyfill.querySelectorAll(element, 'th')
   for (let i = 0; i < headers.length; ++i) {
@@ -191,12 +191,11 @@ const adjustTables = (window, document, pageTitle, isMainPage, isInitiallyCollap
       continue
     }
 
-    // todo: this is actually an array
-    const headerText = getTableHeader(document, table, pageTitle)
-    if (!headerText.length && !isInfobox(table)) {
+    const headerTextArray = getTableHeaderTextArray(document, table, pageTitle)
+    if (!headerTextArray.length && !isInfobox(table)) {
       continue
     }
-    const caption = newCaption(isInfobox(table) ? infoboxTitle : otherTitle, headerText)
+    const caption = newCaption(isInfobox(table) ? infoboxTitle : otherTitle, headerTextArray)
 
     // create the container div that will contain both the original table
     // and the collapsed version.
@@ -294,7 +293,7 @@ export default {
   adjustTables,
   expandCollapsedTableIfItContainsElement,
   test: {
-    getTableHeader,
+    getTableHeaderTextArray,
     shouldTableBeCollapsed,
     isInfobox,
     newCollapsedHeaderDiv,

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -3,6 +3,8 @@ import Polyfill from './Polyfill'
 import elementUtilities from './ElementUtilities'
 
 const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
+const ELEMENT_NODE = 1
+const TEXT_NODE = 3
 
 /**
  * Determine if we want to extract text from this header.
@@ -38,7 +40,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
   fragment.appendChild(header.cloneNode(true))
   const fragmentHeader = fragment.querySelector('th')
 
-  Polyfill.querySelectorAll(fragmentHeader, '.geo, .coordinates, sup.reference')
+  Polyfill.querySelectorAll(fragmentHeader, '.geo, .coordinates, sup.reference, li')
     .forEach(el => el.remove())
 
   if (pageTitle) {
@@ -48,7 +50,12 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
       const alphaNumericText = node.textContent.replace(/[\W_]+/g, '')
       return alphaNumericTitle.indexOf(alphaNumericText) === 0
     }
+    // eslint-disable-next-line require-jsdoc
+    const nodeTypeIsElementOrText = node =>
+      node.nodeType === ELEMENT_NODE || node.nodeType === TEXT_NODE
+
     Array.prototype.slice.call(fragmentHeader.childNodes)
+      .filter(nodeTypeIsElementOrText)
       .filter(nodeTextContentStartsWithPageTitle)
       .forEach(node => node.remove())
   }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -71,7 +71,7 @@ const getTableHeaderTextArray = (document, element, pageTitle) => {
   const headers = Polyfill.querySelectorAll(element, 'th')
   for (let i = 0; i < headers.length; ++i) {
     const headerText = extractEligibleHeaderText(document, headers[i], pageTitle)
-    if (headerText) {
+    if (headerText && headerTextArray.indexOf(headerText) === -1) {
       headerTextArray.push(headerText)
     }
     // 'newCaptionFragment' only ever uses the first 2 items.

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -202,7 +202,7 @@ const newCaptionFragment = (document, title, headerText) => {
 /**
  * @param {!Window} window
  * @param {!Document} document
- * @param {?string} pageTitle
+ * @param {?string} pageTitle use title for this not `display title` (which can contain tags)
  * @param {?boolean} isMainPage
  * @param {?boolean} isInitiallyCollapsed
  * @param {?string} infoboxTitle
@@ -282,7 +282,7 @@ const adjustTables = (window, document, pageTitle, isMainPage, isInitiallyCollap
 /**
  * @param {!Window} window
  * @param {!Document} document
- * @param {?string} pageTitle
+ * @param {?string} pageTitle use title for this not `display title` (which can contain tags)
  * @param {?boolean} isMainPage
  * @param {?string} infoboxTitle
  * @param {?string} otherTitle

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -19,8 +19,9 @@ const isHeaderEligible =
  * @param {?string} headerText
  * @return {!boolean}
  */
-const isHeaderTextEligible = headerText =>
-  headerText && headerText.trim().length > 0 && headerText.replace(/[\s0-9]/g, '').length > 0
+const isHeaderTextEligible = headerText => !(
+  !headerText || headerText.trim().length === 0 || headerText.replace(/[\s0-9]/g, '').length === 0
+)
 
 /**
  * Is node's textContent too similar to pageTitle. Checks if the node's textContent is found at the

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -118,9 +118,11 @@ const elementScopeComparator = (a, b) => {
   const bHasScope = b.hasAttribute('scope')
   if (aHasScope && bHasScope) {
     return 0
-  } else if (aHasScope) {
+  }
+  if (aHasScope) {
     return -1
-  } else if (bHasScope) {
+  }
+  if (bHasScope) {
     return 1
   }
   return 0

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -38,7 +38,7 @@ const extractHeaderText = (document, header) => {
  * @return {!Array<string>}
  */
 const getTableHeaderTextArray = (document, element, pageTitle) => {
-  const thArray = []
+  const headerTextArray = []
   const headers = Polyfill.querySelectorAll(element, 'th')
   for (let i = 0; i < headers.length; ++i) {
     const header = headers[i]
@@ -47,15 +47,15 @@ const getTableHeaderTextArray = (document, element, pageTitle) => {
       // Also ignore it if it's identical to the page title.
       if ((headerText && headerText.length) > 0
         && headerText !== pageTitle && header.innerHTML !== pageTitle) {
-        thArray.push(headerText)
+        headerTextArray.push(headerText)
       }
     }
-    if (thArray.length === 2) {
+    if (headerTextArray.length === 2) {
       // 'newCaption' only ever uses the first 2 items.
       break
     }
   }
-  return thArray
+  return headerTextArray
 }
 
 /**

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -24,16 +24,35 @@ const isHeaderTextEligible = headerText => !(
 )
 
 /**
- * Is node's textContent too similar to pageTitle. Checks if the node's textContent is found at the
- * beginning of pageTitle, but the comparison ignores whitespace, punctuation and dashes, etc.
+ * Extracts first word from string. Returns null if for any reason it is unable to do so.
+ * @param  {!string} string
+ * @return {?string}
+ */
+const firstWordFromString = string => {
+  // 'If the global flag (g) is not set, Element zero of the array contains the entire match,
+  // while elements 1 through n contain any submatches.'
+  const matches = string.match(/\b(\w+)\b/) // Only need first match so not using 'g' option.
+  if (!matches || matches.length === 0) {
+    return null
+  }
+  return matches[0]
+}
+
+/**
+ * Is node's textContent too similar to pageTitle. Checks if the first word of the node's
+ * textContent is found at the beginning of pageTitle.
  * @param  {!node} node
  * @param  {!string} pageTitle
  * @return {!boolean}
  */
-const nodeTextContentSimilarToPageTitle = (node, pageTitle) => {
-  const alphaNumericTitle = pageTitle.replace(/[\W_]+/g, '')
-  const alphaNumericText = node.textContent.replace(/[\W_]+/g, '')
-  return alphaNumericTitle.indexOf(alphaNumericText) === 0
+const isNodeTextContentSimilarToPageTitle = (node, pageTitle) => {
+  const firstPageTitleWord = firstWordFromString(pageTitle)
+  const firstNodeTextContentWord = firstWordFromString(node.textContent)
+  // Don't claim similarity if 1st words were not extracted.
+  if (!firstPageTitleWord || !firstNodeTextContentWord) {
+    return false
+  }
+  return firstPageTitleWord.toLowerCase() === firstNodeTextContentWord.toLowerCase()
 }
 
 /**
@@ -76,7 +95,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
   if (pageTitle) {
     Array.prototype.slice.call(fragmentHeader.childNodes)
       .filter(nodeTypeIsElementOrText)
-      .filter(node => nodeTextContentSimilarToPageTitle(node, pageTitle))
+      .filter(node => isNodeTextContentSimilarToPageTitle(node, pageTitle))
       .forEach(node => node.remove())
   }
 
@@ -369,6 +388,7 @@ export default {
   expandCollapsedTableIfItContainsElement,
   test: {
     extractEligibleHeaderText,
+    firstWordFromString,
     getTableHeaderTextArray,
     shouldTableBeCollapsed,
     isHeaderEligible,
@@ -377,7 +397,7 @@ export default {
     newCollapsedHeaderDiv,
     newCollapsedFooterDiv,
     newCaptionFragment,
-    nodeTextContentSimilarToPageTitle,
+    isNodeTextContentSimilarToPageTitle,
     stringWithNormalizedSpaces
   }
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -63,8 +63,8 @@ const nodeTypeIsElementOrText = node =>
   node.nodeType === ELEMENT_NODE || node.nodeType === TEXT_NODE
 
 /**
- * Removes leading and trailing whitespace and normalizes other spaces - i.e. ensures non-breaking
- * spaces are replaced with regular breaking spaces. 
+ * Removes leading and trailing whitespace and normalizes other whitespace - i.e. ensures
+ * non-breaking spaces, tabs, etc are replaced with regular breaking spaces. 
  * @param  {!string} string
  * @return {!string}
  */

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -15,7 +15,7 @@ const isHeaderEligible = header => Polyfill.querySelectorAll(header, 'a').length
 
 /**
  * Determine eligibility of extracted text.
- * @param {!string} headerText
+ * @param {?string} headerText
  * @param {?string} pageTitle
  * @return {!boolean}
  */

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -40,7 +40,7 @@ const firstWordFromString = string => {
 /**
  * Is node's textContent too similar to pageTitle. Checks if the first word of the node's
  * textContent is found at the beginning of pageTitle.
- * @param  {!node} node
+ * @param  {!Node} node
  * @param  {!string} pageTitle
  * @return {!boolean}
  */
@@ -56,7 +56,7 @@ const isNodeTextContentSimilarToPageTitle = (node, pageTitle) => {
 
 /**
  * Determines if a node is an element or text node.
- * @param  {!node} node
+ * @param  {!Node} node
  * @return {!boolean}
  */
 const nodeTypeIsElementOrText = node =>

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -31,7 +31,7 @@ const isHeaderTextEligible = headerText => !(
 const firstWordFromString = string => {
   // 'If the global flag (g) is not set, Element zero of the array contains the entire match,
   // while elements 1 through n contain any submatches.'
-  const matches = string.match(/\b(\w+)\b/) // Only need first match so not using 'g' option.
+  const matches = string.match(/\w+/) // Only need first match so not using 'g' option.
   if (!matches || matches.length === 0) {
     return null
   }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -19,7 +19,8 @@ const isHeaderEligible =
  * @param {?string} headerText
  * @return {!boolean}
  */
-const isHeaderTextEligible = headerText => headerText && headerText.trim().length > 0
+const isHeaderTextEligible = headerText =>
+  headerText && headerText.trim().length > 0 && headerText.replace(/[\s0-9]/g, '').length > 0
 
 /**
  * Is node's textContent too similar to pageTitle. Checks if the node's textContent is found at the

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -42,9 +42,12 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
     .forEach(el => el.remove())
 
   if (pageTitle) {
-    // eslint-disable-next-line require-jsdoc
-    const nodeTextContentStartsWithPageTitle = node =>
-      pageTitle.indexOf(node.textContent.trim()) === 0
+    const nodeTextContentStartsWithPageTitle = node => { // eslint-disable-line require-jsdoc
+      // Make the comparison ignore whitespace, punctuation and dashes, etc.
+      const alphaNumericTitle = pageTitle.replace(/[\W_]+/g, '')
+      const alphaNumericText = node.textContent.replace(/[\W_]+/g, '')
+      return alphaNumericTitle.indexOf(alphaNumericText) === 0
+    }
     Array.prototype.slice.call(fragmentHeader.childNodes)
       .filter(nodeTextContentStartsWithPageTitle)
       .forEach(node => node.remove())

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -50,7 +50,7 @@ const nodeTypeIsElementOrText = node =>
  * @param  {!string} string
  * @return {!string}
  */
-const stringWithNormalizeSpaces = string => string.trim().replace(/\s/g, ' ')
+const stringWithNormalizedSpaces = string => string.trim().replace(/\s/g, ' ')
 
 /**
  * Extracts any header text determined to be eligible.
@@ -82,7 +82,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
 
   const headerText = fragmentHeader.textContent
   if (isHeaderTextEligible(headerText)) {
-    return stringWithNormalizeSpaces(headerText)
+    return stringWithNormalizedSpaces(headerText)
   }
   return null
 }
@@ -378,6 +378,6 @@ export default {
     newCollapsedFooterDiv,
     newCaptionFragment,
     nodeTextContentSimilarToPageTitle,
-    stringWithNormalizeSpaces
+    stringWithNormalizedSpaces
   }
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -28,7 +28,7 @@ const isHeaderTextEligible = headerText => !(
  * beginning of pageTitle, but the comparison ignores whitespace, punctuation and dashes, etc.
  * @param  {!node} node
  * @param  {!string} pageTitle
- * @return {[type]}
+ * @return {!boolean}
  */
 const nodeTextContentSimilarToPageTitle = (node, pageTitle) => {
   const alphaNumericTitle = pageTitle.replace(/[\W_]+/g, '')
@@ -43,6 +43,14 @@ const nodeTextContentSimilarToPageTitle = (node, pageTitle) => {
  */
 const nodeTypeIsElementOrText = node =>
   node.nodeType === ELEMENT_NODE || node.nodeType === TEXT_NODE
+
+/**
+ * Removes leading and trailing whitespace and normalizes other spaces - i.e. ensures non-breaking
+ * spaces are replaced with regular breaking spaces. 
+ * @param  {!string} string
+ * @return {!string}
+ */
+const stringWithNormalizeSpaces = string => string.trim().replace(/\s/g, ' ')
 
 /**
  * Extracts any header text determined to be eligible.
@@ -74,7 +82,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
 
   const headerText = fragmentHeader.textContent
   if (isHeaderTextEligible(headerText)) {
-    return headerText.trim()
+    return stringWithNormalizeSpaces(headerText)
   }
   return null
 }
@@ -369,6 +377,7 @@ export default {
     newCollapsedHeaderDiv,
     newCollapsedFooterDiv,
     newCaptionFragment,
-    nodeTextContentSimilarToPageTitle
+    nodeTextContentSimilarToPageTitle,
+    stringWithNormalizeSpaces
   }
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -107,6 +107,27 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
 }
 
 /**
+ * Used to sort array of Elements so those containing 'scope' attribute are moved to front of
+ * array. Relative order between 'scope' elements is preserved. Relative order between non 'scope'
+ * elements is preserved.
+ * @param  {!Element} a
+ * @param  {!Element} b
+ * @return {!boolean}
+ */
+const elementScopeComparator = (a, b) => {
+  const aHasScope = a.hasAttribute('scope')
+  const bHasScope = b.hasAttribute('scope')
+  if (aHasScope && bHasScope) {
+    return 0
+  } else if (aHasScope) {
+    return -1
+  } else if (bHasScope) {
+    return 1
+  }
+  return 0
+}
+
+/**
  * Find an array of table header (TH) contents. If there are no TH elements in
  * the table or the header's link matches pageTitle, an empty array is returned.
  * @param {!Document} document
@@ -118,6 +139,7 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
 const getTableHeaderTextArray = (document, element, pageTitle) => {
   const headerTextArray = []
   const headers = Polyfill.querySelectorAll(element, 'th')
+  headers.sort(elementScopeComparator)
   for (let i = 0; i < headers.length; ++i) {
     const headerText = extractEligibleHeaderText(document, headers[i], pageTitle)
     if (headerText && headerTextArray.indexOf(headerText) === -1) {
@@ -387,6 +409,7 @@ export default {
   adjustTables,
   expandCollapsedTableIfItContainsElement,
   test: {
+    elementScopeComparator,
     extractEligibleHeaderText,
     firstWordFromString,
     getTableHeaderTextArray,

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -143,10 +143,10 @@ const getTableHeaderTextArray = (document, element, pageTitle) => {
     const headerText = extractEligibleHeaderText(document, headers[i], pageTitle)
     if (headerText && headerTextArray.indexOf(headerText) === -1) {
       headerTextArray.push(headerText)
-    }
-    // 'newCaptionFragment' only ever uses the first 2 items.
-    if (headerTextArray.length === 2) {
-      break
+      // 'newCaptionFragment' only ever uses the first 2 items.
+      if (headerTextArray.length === 2) {
+        break
+      }
     }
   }
   return headerTextArray

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -19,9 +19,8 @@ const isHeaderEligible =
  * @param {?string} headerText
  * @return {!boolean}
  */
-const isHeaderTextEligible = headerText => !(
-  !headerText || headerText.trim().length === 0 || headerText.replace(/[\s0-9]/g, '').length === 0
-)
+const isHeaderTextEligible = headerText =>
+  headerText && headerText.replace(/[\s0-9]/g, '').length > 0
 
 /**
  * Extracts first word from string. Returns null if for any reason it is unable to do so.

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -31,8 +31,8 @@ const firstWordFromString = string => {
   // 'If the global flag (g) is not set, Element zero of the array contains the entire match,
   // while elements 1 through n contain any submatches.'
   const matches = string.match(/\w+/) // Only need first match so not using 'g' option.
-  if (!matches || matches.length === 0) {
-    return null
+  if (!matches) {
+    return undefined
   }
   return matches[0]
 }

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -5,6 +5,23 @@ import elementUtilities from './ElementUtilities'
 const SECTION_TOGGLED_EVENT_TYPE = 'section-toggled'
 
 /**
+ * Extracts header text.
+ * @param {!Document} document
+ * @param {!Element} header
+ * @return {?string}
+ */
+const extractHeaderText = (document, header) => {
+  // Clone header into fragment. This is done so we can remove some elements we don't want
+  // represented when "textContent" is used. Because we've cloned the header into a fragment, we are
+  // free to strip out anything we want without worrying about affecting the visible document.
+  const fragment = document.createDocumentFragment()
+  fragment.appendChild(header.cloneNode(true)) // eslint-disable-line require-jsdoc
+  Polyfill.querySelectorAll(fragment, '.geo, .coordinates, sup.reference')
+    .forEach(el => el.remove())
+  return fragment.textContent
+}
+
+/**
  * Find an array of table header (TH) contents. If there are no TH elements in
  * the table or the header's link matches pageTitle, an empty array is returned.
  * @param {!Document} document
@@ -20,16 +37,7 @@ const getTableHeaderTextArray = (document, element, pageTitle) => {
     const header = headers[i]
     const anchors = Polyfill.querySelectorAll(header, 'a')
     if (anchors.length < 3) {
-      // Clone header into fragment. This is done so we can remove some elements we don't want
-      // represented when "textContent" is used. Because we've cloned the header into a fragment, we
-      // are free to strip out anything we want without worrying about affecting the visible
-      // document.
-      const fragment = document.createDocumentFragment()
-      fragment.appendChild(header.cloneNode(true)) // eslint-disable-line require-jsdoc
-      Polyfill.querySelectorAll(fragment, '.geo, .coordinates, sup.reference')
-        .forEach(el => el.remove())
-      const headerText = fragment.textContent
-
+      const headerText = extractHeaderText(document, header)
       // Also ignore it if it's identical to the page title.
       if ((headerText && headerText.length) > 0
         && headerText !== pageTitle && header.innerHTML !== pageTitle) {

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -22,7 +22,7 @@ const extractHeaderText = (document, header) => {
   // represented when "textContent" is used. Because we've cloned the header into a fragment, we are
   // free to strip out anything we want without worrying about affecting the visible document.
   const fragment = document.createDocumentFragment()
-  fragment.appendChild(header.cloneNode(true)) // eslint-disable-line require-jsdoc
+  fragment.appendChild(header.cloneNode(true))
   Polyfill.querySelectorAll(fragment, '.geo, .coordinates, sup.reference')
     .forEach(el => el.remove())
   return fragment.textContent.trim()

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -101,6 +101,13 @@ describe('CollapseTable', () => {
       const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
       assert.equal(text, null)
     })
+    it('text equal to page title returns null ignoring non-alphaNumeric characters', () => {
+      // 'enwiki > Brussels-Chapel railway station'
+      const doc = domino.createDocument('<table><tr><th>SampleTitle</th></tr></table>')
+      const header = doc.querySelector('th')
+      const text = extractEligibleHeaderText(doc, header, 'Sample-Title')
+      assert.equal(text, null)
+    })
     it('extracted text excludes ref links', () => {
       const doc = domino.createDocument(
         '<table><tr><th>Some text <sup class=reference>[1]</sup></th></tr></table>'

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -172,6 +172,12 @@ describe('CollapseTable', () => {
           assert.deepEqual(actual, [])
         })
 
+        it('and two headers have identical text', () => {
+          const doc = domino.createDocument('<table><tr><th>type</th><th>type</th></tr></table>')
+          const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
+          assert.deepEqual(actual, ['type'])
+        })
+
         describe('and link is nonempty', () => {
           it('and doesn\'t match page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -873,4 +873,18 @@ describe('CollapseTable', () => {
       assert.deepEqual(headers.map(el => el.id), ['2', '3', '6', '7', '0', '1', '4', '5'])
     })
   })
+
+  describe('replaceNodeWithBreakingSpaceTextNode()', () => {
+    const replaceNodeWithBreakingSpaceTextNode =
+      pagelib.CollapseTable.test.replaceNodeWithBreakingSpaceTextNode
+
+    it('Replaces BR with single breaking space', () => {
+      // 'enwiki > Greece'
+      const doc = domino.createDocument(`
+        <span>Capital<br>and largest city</span>
+      `)
+      replaceNodeWithBreakingSpaceTextNode(doc, doc.querySelector('br'))
+      assert.equal(doc.querySelector('span').textContent, 'Capital and largest city')
+    })
+  })
 })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -72,6 +72,19 @@ describe('CollapseTable', () => {
       const isEligible = isHeaderTextEligible(headerText)
       assert.equal(isEligible, false)
     })
+    it('node with only numbers is rejected', () => {
+      // 'enwiki > Lyublinsko-Dmitrovskaya line'
+      const doc = domino.createDocument('<table><tr><th>123</th></tr></table>')
+      const headerText = doc.querySelector('th').textContent
+      const isEligible = isHeaderTextEligible(headerText)
+      assert.equal(isEligible, false)
+    })
+    it('node with only numbers and whitespace is rejected', () => {
+      const doc = domino.createDocument('<table><tr><th> 123 </th></tr></table>')
+      const headerText = doc.querySelector('th').textContent
+      const isEligible = isHeaderTextEligible(headerText)
+      assert.equal(isEligible, false)
+    })
   })
 
   describe('extractEligibleHeaderText()', () => {

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -3,51 +3,51 @@ import domino from 'domino'
 import pagelib from '../../build/wikimedia-page-library-transform'
 
 describe('CollapseTable', () => {
-  describe('getTableHeader()', () => {
-    const getTableHeader = pagelib.CollapseTable.test.getTableHeader
+  describe('getTableHeaderTextArray()', () => {
+    const getTableHeaderTextArray = pagelib.CollapseTable.test.getTableHeaderTextArray
 
     it('when no table, shouldn\'t find headers', () => {
       const doc = domino.createDocument('<html></html>')
-      const actual = getTableHeader(doc, doc.documentElement, 'pageTitle')
+      const actual = getTableHeaderTextArray(doc, doc.documentElement, 'pageTitle')
       assert.deepEqual(actual, [])
     })
 
     describe('when table', () => {
       it('and no header, shouldn\'t find headers', () => {
         const doc = domino.createDocument('<table></table>')
-        const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
+        const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
         assert.deepEqual(actual, [])
       })
 
       it('and header is empty, shouldn\'t find headers', () => {
         const doc = domino.createDocument('<table><tr><th></th></tr></table>')
-        const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
+        const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
         assert.deepEqual(actual, [])
       })
 
       describe('and header is nonempty', () => {
         it('and link is empty, shouldn\'t find header', () => {
           const doc = domino.createDocument('<table><tr><th><a></a></th></tr></table>')
-          const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
+          const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
           assert.deepEqual(actual, [])
         })
 
         describe('and link is nonempty', () => {
           it('and doesn\'t match page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')
-            const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
+            const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
             assert.deepEqual(actual, ['text'])
           })
 
           it('and matches page title, shouldn\'t find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>pageTitle</a></th></tr></table>')
-            const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
+            const actual = getTableHeaderTextArray(doc, doc.querySelector('table'), 'pageTitle')
             assert.deepEqual(actual, [])
           })
 
           it('and no page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')
-            const actual = getTableHeader(doc, doc.querySelector('table'))
+            const actual = getTableHeaderTextArray(doc, doc.querySelector('table'))
             assert.deepEqual(actual, ['text'])
           })
         })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -8,46 +8,46 @@ describe('CollapseTable', () => {
 
     it('when no table, shouldn\'t find headers', () => {
       const doc = domino.createDocument('<html></html>')
-      const actual = getTableHeader(doc.documentElement, 'pageTitle')
+      const actual = getTableHeader(doc, doc.documentElement, 'pageTitle')
       assert.deepEqual(actual, [])
     })
 
     describe('when table', () => {
       it('and no header, shouldn\'t find headers', () => {
         const doc = domino.createDocument('<table></table>')
-        const actual = getTableHeader(doc.querySelector('table'), 'pageTitle')
+        const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
         assert.deepEqual(actual, [])
       })
 
       it('and header is empty, shouldn\'t find headers', () => {
         const doc = domino.createDocument('<table><tr><th></th></tr></table>')
-        const actual = getTableHeader(doc.querySelector('table'), 'pageTitle')
+        const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
         assert.deepEqual(actual, [])
       })
 
       describe('and header is nonempty', () => {
         it('and link is empty, shouldn\'t find header', () => {
           const doc = domino.createDocument('<table><tr><th><a></a></th></tr></table>')
-          const actual = getTableHeader(doc.querySelector('table'), 'pageTitle')
+          const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
           assert.deepEqual(actual, [])
         })
 
         describe('and link is nonempty', () => {
           it('and doesn\'t match page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')
-            const actual = getTableHeader(doc.querySelector('table'), 'pageTitle')
+            const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
             assert.deepEqual(actual, ['text'])
           })
 
           it('and matches page title, shouldn\'t find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>pageTitle</a></th></tr></table>')
-            const actual = getTableHeader(doc.querySelector('table'), 'pageTitle')
+            const actual = getTableHeader(doc, doc.querySelector('table'), 'pageTitle')
             assert.deepEqual(actual, [])
           })
 
           it('and no page title, should find header', () => {
             const doc = domino.createDocument('<table><tr><th><a>text</a></th></tr></table>')
-            const actual = getTableHeader(doc.querySelector('table'))
+            const actual = getTableHeader(doc, doc.querySelector('table'))
             assert.deepEqual(actual, ['text'])
           })
         })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -132,13 +132,13 @@ describe('CollapseTable', () => {
       const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
       assert.equal(text, null)
     })
-    it('text equal to page title returns null ignoring non-alphaNumeric characters', () => {
-      // 'enwiki > Brussels-Chapel railway station'
-      const doc = domino.createDocument('<table><tr><th>SampleTitle</th></tr></table>')
-      const header = doc.querySelector('th')
-      const text = extractEligibleHeaderText(doc, header, 'Sample-Title')
-      assert.equal(text, null)
-    })
+    // it('text equal to page title returns null ignoring non-alphaNumeric characters', () => {
+    //   // 'enwiki > Brussels-Chapel railway station'
+    //   const doc = domino.createDocument('<table><tr><th>SampleTitle</th></tr></table>')
+    //   const header = doc.querySelector('th')
+    //   const text = extractEligibleHeaderText(doc, header, 'Sample-Title')
+    //   assert.equal(text, null)
+    // })
     it('extracted text excludes ref links', () => {
       const doc = domino.createDocument(
         '<table><tr><th>Some text <sup class=reference>[1]</sup></th></tr></table>'
@@ -214,34 +214,75 @@ describe('CollapseTable', () => {
       })
   })
 
-  describe('nodeTextContentSimilarToPageTitle()', () => {
-    const nodeTextContentSimilarToPageTitle =
-      pagelib.CollapseTable.test.nodeTextContentSimilarToPageTitle
+  describe('isNodeTextContentSimilarToPageTitle()', () => {
+    const isNodeTextContentSimilarToPageTitle =
+      pagelib.CollapseTable.test.isNodeTextContentSimilarToPageTitle
 
     describe('TH node textContent and page title considered similar', () => {
       describe('when page title starts with textContent', () => {
+        it('full exact match', () => {
+          const doc = domino.createDocument('<table><tr><th>Brussels</th></tr></table>')
+          const th = doc.querySelector('th')
+          const pageTitle = 'Brussels'
+          const isSimilar = isNodeTextContentSimilarToPageTitle(th, pageTitle)
+          assert.equal(isSimilar, true)
+        })
         // 'enwiki > Brussels-Chapel railway station'
-        it('exactly', () => {
+        // 'enwiki > Matthew H. Clark'
+        // 'enwiki > Adolf Ehrnrooth'
+        it('starting exact match', () => {
           const doc = domino.createDocument('<table><tr><th>Brussels</th></tr></table>')
           const th = doc.querySelector('th')
           const pageTitle = 'Brussels Railway'
-          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          const isSimilar = isNodeTextContentSimilarToPageTitle(th, pageTitle)
           assert.equal(isSimilar, true)
         })
         it('and whitespace ignored', () => {
           const doc = domino.createDocument('<table><tr><th> Brussels </th></tr></table>')
           const th = doc.querySelector('th')
           const pageTitle = 'Brussels Railway'
-          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          const isSimilar = isNodeTextContentSimilarToPageTitle(th, pageTitle)
           assert.equal(isSimilar, true)
         })
         it('and non-alphaNumeric text ignored', () => {
           const doc = domino.createDocument('<table><tr><th>Brussels</th></tr></table>')
           const th = doc.querySelector('th')
           const pageTitle = 'Brussels-Railway'
-          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          const isSimilar = isNodeTextContentSimilarToPageTitle(th, pageTitle)
           assert.equal(isSimilar, true)
         })
+      })
+    })
+  })
+
+  describe('firstWordFromString()', () => {
+    const firstWordFromString = pagelib.CollapseTable.test.firstWordFromString
+    describe('gets first word', () => {
+      it('from sentence', () => {
+        assert.equal(firstWordFromString('food is good'), 'food')
+      })
+      it('from word', () => {
+        assert.equal(firstWordFromString('food'), 'food')
+      })
+      it('from word followed by dash', () => {
+        assert.equal(firstWordFromString('food-'), 'food')
+      })
+      it('from word followed by punctuation', () => {
+        assert.equal(firstWordFromString('food.'), 'food')
+      })
+    })
+    describe('gets null', () => {
+      it('from zero length string', () => {
+        assert.equal(firstWordFromString(''), null)
+      })
+      it('from whitespace string', () => {
+        assert.equal(firstWordFromString(' '), null)
+      })
+      it('from punctuation string', () => {
+        assert.equal(firstWordFromString('.'), null)
+      })
+      it('from dash string', () => {
+        assert.equal(firstWordFromString('-'), null)
       })
     })
   })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -35,29 +35,29 @@ describe('CollapseTable', () => {
     })
   })
 
-  describe('stringWithNormalizedSpaces()', () => {
+  describe('stringWithNormalizedWhitespace()', () => {
     // 'enwiki > Bonar Bridge'
-    const stringWithNormalizedSpaces = pagelib.CollapseTable.test.stringWithNormalizedSpaces
+    const stringWithNormalizedWhitespace = pagelib.CollapseTable.test.stringWithNormalizedWhitespace
     it('leading and trailing whitespace is trimmed', () => {
-      assert.equal(stringWithNormalizedSpaces(' hi '), 'hi')
+      assert.equal(stringWithNormalizedWhitespace(' hi '), 'hi')
     })
     it('non-leading/trailing non-breaking spaces converted to breaking spaces', () => {
-      assert.equal(stringWithNormalizedSpaces(
+      assert.equal(stringWithNormalizedWhitespace(
         domino.createDocument('hi&nbsp;hi').childNodes[0].textContent
       ), 'hi hi')
     })
     it('leading and trailing non-breaking spaces trimmed', () => {
-      assert.equal(stringWithNormalizedSpaces(
+      assert.equal(stringWithNormalizedWhitespace(
         domino.createDocument('&nbsp;hi hi&nbsp;').childNodes[0].textContent
       ), 'hi hi')
     })
     it('tabs trimmed', () => {
-      assert.equal(stringWithNormalizedSpaces(
+      assert.equal(stringWithNormalizedWhitespace(
         domino.createDocument('\thi\t').childNodes[0].textContent
       ), 'hi')
     })
     it('non-leading tabs converted to breaking spaces', () => {
-      assert.equal(stringWithNormalizedSpaces(
+      assert.equal(stringWithNormalizedWhitespace(
         domino.createDocument('hi\thi').childNodes[0].textContent
       ), 'hi hi')
     })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -133,13 +133,6 @@ describe('CollapseTable', () => {
       const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
       assert.equal(text, null)
     })
-    // it('text equal to page title returns null ignoring non-alphaNumeric characters', () => {
-    //   // 'enwiki > Brussels-Chapel railway station'
-    //   const doc = domino.createDocument('<table><tr><th>SampleTitle</th></tr></table>')
-    //   const header = doc.querySelector('th')
-    //   const text = extractEligibleHeaderText(doc, header, 'Sample-Title')
-    //   assert.equal(text, null)
-    // })
     it('extracted text excludes ref links', () => {
       const doc = domino.createDocument(
         '<table><tr><th>Some text <sup class=reference>[1]</sup></th></tr></table>'

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -4,6 +4,35 @@ import pagelib from '../../build/wikimedia-page-library-transform'
 
 describe('CollapseTable', () => {
 
+  describe('nodeHasNonWhitespaceTextContent()', () => {
+    const nodeHasNonWhitespaceTextContent =
+      pagelib.CollapseTable.test.nodeHasNonWhitespaceTextContent
+    it('node with only comment is rejected', () => {
+      const doc = domino.createDocument('<table><tr><th><!--Comment--></th></tr></table>')
+      const header = doc.querySelector('th')
+      const foundText = nodeHasNonWhitespaceTextContent(header)
+      assert.equal(foundText, false)
+    })
+    it('node with only whitespace is rejected', () => {
+      const doc = domino.createDocument('<table><tr><th>   </th></tr></table>')
+      const header = doc.querySelector('th')
+      const foundText = nodeHasNonWhitespaceTextContent(header)
+      assert.equal(foundText, false)
+    })
+    it('node with only comment and whitespace is rejected', () => {
+      const doc = domino.createDocument('<table><tr><th>   <!--Comment-->   </th></tr></table>')
+      const header = doc.querySelector('th')
+      const foundText = nodeHasNonWhitespaceTextContent(header)
+      assert.equal(foundText, false)
+    })
+    it('node with no text is rejected', () => {
+      const doc = domino.createDocument('<table><tr><th></th></tr></table>')
+      const header = doc.querySelector('th')
+      const foundText = nodeHasNonWhitespaceTextContent(header)
+      assert.equal(foundText, false)
+    })
+  })
+
   describe('isHeaderEligible()', () => {
     const isHeaderEligible = pagelib.CollapseTable.test.isHeaderEligible
     it('when too many links, should not be eligible', () => {

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -130,6 +130,39 @@ describe('CollapseTable', () => {
       const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
       assert.equal(text, 'Some text')
     })
+    it('extracted text excludes li', () => {
+      // 'enwiki > Brussels-Chapel railway station'
+      const doc = domino.createDocument(`
+        <table><tr>
+          <th>
+            <ul>
+              <li>this
+              <li>that
+            </ul>
+          </th>
+        </tr></table>
+      `)
+      const header = doc.querySelector('th')
+      const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
+      assert.equal(text, null)
+    })
+    it('extracted text excludes li but grabs non-li text', () => {
+      // 'enwiki > Brussels-Chapel railway station'
+      const doc = domino.createDocument(`
+        <table><tr>
+          <th>
+            <ul>
+              <li>this
+              <li>that
+            </ul>
+            <i>goat</i>
+          </th>
+        </tr></table>
+      `)
+      const header = doc.querySelector('th')
+      const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
+      assert.equal(text, 'goat')
+    })
     it('extracted text skips element if page title starts with element textContent', () => {
       // 'dewiki > Hornburg (Mansfelder Land)'
       // 'enwiki > Ramon Magsaysay High School, Manila'

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -34,6 +34,24 @@ describe('CollapseTable', () => {
     })
   })
 
+  describe('stringWithNormalizeSpaces()', () => {
+    // 'enwiki > Bonar Bridge'
+    const stringWithNormalizeSpaces = pagelib.CollapseTable.test.stringWithNormalizeSpaces
+    it('leading and trailing whitespace is trimmed', () => {
+      assert.equal(stringWithNormalizeSpaces(' hi '), 'hi')
+    })
+    it('non-leading/trailing non-breaking spaces converted to breaking spaces', () => {
+      assert.equal(stringWithNormalizeSpaces(
+        domino.createDocument('hi&nbsp;hi').childNodes[0].textContent
+      ), 'hi hi')
+    })
+    it('leading and trailing non-breaking spaces trimmed', () => {
+      assert.equal(stringWithNormalizeSpaces(
+        domino.createDocument('&nbsp;hi hi&nbsp;').childNodes[0].textContent
+      ), 'hi hi')
+    })
+  })
+
   describe('isHeaderTextEligible()', () => {
     const isHeaderTextEligible = pagelib.CollapseTable.test.isHeaderTextEligible
     it('undefined text is rejected', () => {

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -51,6 +51,16 @@ describe('CollapseTable', () => {
         domino.createDocument('&nbsp;hi hi&nbsp;').childNodes[0].textContent
       ), 'hi hi')
     })
+    it('tabs trimmed', () => {
+      assert.equal(stringWithNormalizedSpaces(
+        domino.createDocument('\thi\t').childNodes[0].textContent
+      ), 'hi')
+    })
+    it('non-leading tabs converted to breaking spaces', () => {
+      assert.equal(stringWithNormalizedSpaces(
+        domino.createDocument('hi\thi').childNodes[0].textContent
+      ), 'hi hi')
+    })
   })
 
   describe('isHeaderTextEligible()', () => {

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -34,19 +34,19 @@ describe('CollapseTable', () => {
     })
   })
 
-  describe('stringWithNormalizeSpaces()', () => {
+  describe('stringWithNormalizedSpaces()', () => {
     // 'enwiki > Bonar Bridge'
-    const stringWithNormalizeSpaces = pagelib.CollapseTable.test.stringWithNormalizeSpaces
+    const stringWithNormalizedSpaces = pagelib.CollapseTable.test.stringWithNormalizedSpaces
     it('leading and trailing whitespace is trimmed', () => {
-      assert.equal(stringWithNormalizeSpaces(' hi '), 'hi')
+      assert.equal(stringWithNormalizedSpaces(' hi '), 'hi')
     })
     it('non-leading/trailing non-breaking spaces converted to breaking spaces', () => {
-      assert.equal(stringWithNormalizeSpaces(
+      assert.equal(stringWithNormalizedSpaces(
         domino.createDocument('hi&nbsp;hi').childNodes[0].textContent
       ), 'hi hi')
     })
     it('leading and trailing non-breaking spaces trimmed', () => {
-      assert.equal(stringWithNormalizeSpaces(
+      assert.equal(stringWithNormalizedSpaces(
         domino.createDocument('&nbsp;hi hi&nbsp;').childNodes[0].textContent
       ), 'hi hi')
     })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -183,6 +183,38 @@ describe('CollapseTable', () => {
       })
   })
 
+  describe('nodeTextContentSimilarToPageTitle()', () => {
+    const nodeTextContentSimilarToPageTitle =
+      pagelib.CollapseTable.test.nodeTextContentSimilarToPageTitle
+
+    describe('TH node textContent and page title considered similar', () => {
+      describe('when page title starts with textContent', () => {
+        // 'enwiki > Brussels-Chapel railway station'
+        it('exactly', () => {
+          const doc = domino.createDocument('<table><tr><th>Brussels</th></tr></table>')
+          const th = doc.querySelector('th')
+          const pageTitle = 'Brussels Railway'
+          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          assert.equal(isSimilar, true)
+        })
+        it('and whitespace ignored', () => {
+          const doc = domino.createDocument('<table><tr><th> Brussels </th></tr></table>')
+          const th = doc.querySelector('th')
+          const pageTitle = 'Brussels Railway'
+          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          assert.equal(isSimilar, true)
+        })
+        it('and non-alphaNumeric text ignored', () => {
+          const doc = domino.createDocument('<table><tr><th>Brussels</th></tr></table>')
+          const th = doc.querySelector('th')
+          const pageTitle = 'Brussels-Railway'
+          const isSimilar = nodeTextContentSimilarToPageTitle(th, pageTitle)
+          assert.equal(isSimilar, true)
+        })
+      })
+    })
+  })
+
   describe('getTableHeaderTextArray()', () => {
     const getTableHeaderTextArray = pagelib.CollapseTable.test.getTableHeaderTextArray
 

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -202,27 +202,39 @@ describe('CollapseTable', () => {
     const newCollapsedHeaderDiv = pagelib.CollapseTable.test.newCollapsedHeaderDiv
 
     it('the div is created', () => {
-      const div = newCollapsedHeaderDiv(domino.createDocument())
+      const doc = domino.createDocument()
+      const frag = doc.createDocumentFragment()
+      const div = newCollapsedHeaderDiv(doc, frag)
       assert.ok(div instanceof domino.impl.HTMLDivElement)
     })
 
     it('the div is a container', () => {
-      const div = newCollapsedHeaderDiv(domino.createDocument())
+      const doc = domino.createDocument()
+      const frag = doc.createDocumentFragment()
+      const div = newCollapsedHeaderDiv(doc, frag)
       assert.ok(div.classList.contains('pagelib_collapse_table_collapsed_container'))
     })
 
     it('the div is expanded', () => {
-      const div = newCollapsedHeaderDiv(domino.createDocument())
+      const doc = domino.createDocument()
+      const frag = doc.createDocumentFragment()
+      const div = newCollapsedHeaderDiv(doc, frag)
       assert.ok(div.classList.contains('pagelib_collapse_table_expanded'))
     })
 
     it('when contents is undefined, the div has no contents', () => {
-      const div = newCollapsedHeaderDiv(domino.createDocument())
+      const doc = domino.createDocument()
+      const frag = doc.createDocumentFragment()
+      const div = newCollapsedHeaderDiv(doc, frag)
       assert.ok(!div.innerHTML)
     })
 
     it('when contents are defined, the div has contents', () => {
-      const div = newCollapsedHeaderDiv(domino.createDocument(), 'contents')
+      const doc = domino.createDocument()
+      const frag = doc.createDocumentFragment()
+      const text = doc.createTextNode('contents')
+      frag.appendChild(text)
+      const div = newCollapsedHeaderDiv(doc, frag)
       assert.deepEqual(div.innerHTML, 'contents')
     })
   })
@@ -256,54 +268,53 @@ describe('CollapseTable', () => {
     })
   })
 
-  describe('newCaption()', () => {
-    const newCaption = pagelib.CollapseTable.test.newCaption
+  describe('newCaptionFragment()', () => {
+    const newCaptionFragment = pagelib.CollapseTable.test.newCaptionFragment
 
     describe('when no header text', () => {
-      const caption = newCaption('title', [])
-
+      const caption = newCaptionFragment(domino.createDocument(), 'title', [])
       it('the title is present', () => {
-        assert.ok(caption.includes('title'))
+        assert.ok(caption.textContent.includes('title'))
       })
 
       it('no additional text is shown', () => {
-        assert.ok(!caption.includes(','))
+        assert.ok(!caption.textContent.includes(','))
       })
     })
 
     describe('when a one element header text', () => {
-      const caption = newCaption('title', ['0'])
+      const caption = newCaptionFragment(domino.createDocument(), 'title', ['0'])
 
       it('the title is present', () => {
-        assert.ok(caption.includes('title'))
+        assert.ok(caption.textContent.includes('title'))
       })
 
       it('the first entry is shown', () => {
-        assert.ok(caption.includes('0'))
+        assert.ok(caption.textContent.includes('0'))
       })
 
       it('an ellipsis is shown', () => {
-        assert.ok(caption.includes('…'))
+        assert.ok(caption.textContent.includes('…'))
       })
     })
 
     describe('when a two element header text', () => {
-      const caption = newCaption('title', ['0', '1'])
+      const caption = newCaptionFragment(domino.createDocument(), 'title', ['0', '1'])
 
       it('the title is present', () => {
-        assert.ok(caption.includes('title'))
+        assert.ok(caption.textContent.includes('title'))
       })
 
       it('the first entry is shown', () => {
-        assert.ok(caption.includes('0'))
+        assert.ok(caption.textContent.includes('0'))
       })
 
       it('an ellipsis is shown', () => {
-        assert.ok(caption.includes('…'))
+        assert.ok(caption.textContent.includes('…'))
       })
 
       it('the second entry is shown', () => {
-        assert.ok(caption.includes('1'))
+        assert.ok(caption.textContent.includes('1'))
       })
     })
   })

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -1,6 +1,7 @@
 import assert from 'assert'
 import domino from 'domino'
 import pagelib from '../../build/wikimedia-page-library-transform'
+const Polyfill = pagelib.test.Polyfill
 
 describe('CollapseTable', () => {
 
@@ -809,7 +810,6 @@ describe('CollapseTable', () => {
   })
 
   describe('expandCollapsedTableIfItContainsElement()', () => {
-    // eslint-disable-next-line max-len
     const expandCollapsedTableIfItContainsElement =
       pagelib.CollapseTable.expandCollapsedTableIfItContainsElement
 
@@ -846,6 +846,28 @@ describe('CollapseTable', () => {
           expandCollapsedTableIfItContainsElement(element)
         })
       })
+    })
+  })
+
+  describe('elementScopeComparator()', () => {
+    const elementScopeComparator = pagelib.CollapseTable.test.elementScopeComparator
+    it('elements sorted favoring those having scope with relative order preserved', () => {
+      // 'enwiki > Charled H. Bartlett'
+      const doc = domino.createDocument(`
+        <table>
+        <th id=0>header 0</th>
+        <th id=1>header 1</th>
+        <th scope=row id=2>header 2</th>
+        <th scope=row id=3>header 3</th>
+        <th id=4>header 4</th>
+        <th id=5>header 5</th>
+        <th scope=row id=6>header 6</th>
+        <th scope=row id=7>header 7</th>
+        </table>
+      `)
+      const headers = Polyfill.querySelectorAll(doc, 'th')
+      headers.sort(elementScopeComparator)
+      assert.deepEqual(headers.map(el => el.id), ['2', '3', '6', '7', '0', '1', '4', '5'])
     })
   })
 })


### PR DESCRIPTION
https://phabricator.wikimedia.org/T185249

I began to decompose some overly stuffed methods to make them easier to grok and test.
Also got rid of some string appending.

<table>
  <tr>
    <td align=center><h2>Before</h2></td>
    <td align=center><h2>After</h2></td>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>exclude geo and coords from titles</h3></td>
  </tr>
  <tr>
    <td colspan="2" align=center>dewiki > Hornburg (Mansfelder Land)</td>
  </tr>
  <tr>
    <td>
<img alt="screen shot 2018-01-18 at 12 16 45 am" src="https://user-images.githubusercontent.com/3143487/35087473-27421dcc-fbe5-11e7-8d11-54cc2d2ed18e.png">    
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 2 33 08 pm" src="https://user-images.githubusercontent.com/3143487/35174848-b45aa760-fd25-11e7-8e01-75bef40746e2.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>exclude ref links</h3></td>
  </tr>
  <tr>
    <td colspan="2" align=center>enwiki > Fairhaven Station > Boardings and alightings</td>
  </tr>
  <tr>
    <td>
<img alt="screen shot 2018-01-18 at 12 16 30 am" src="https://user-images.githubusercontent.com/3143487/35087475-27579da0-fbe5-11e7-983b-614401ce357c.png">
    </td>
    <td>
<img alt="screen shot 2018-01-18 at 12 23 00 am" src="https://user-images.githubusercontent.com/3143487/35087648-cdb25a0a-fbe5-11e7-8c79-4e0163af7d11.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>better title extraction</h3></td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 2 35 47 pm" src="https://user-images.githubusercontent.com/3143487/35175004-8645d29a-fd26-11e7-8de3-196201405603.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 46 04 pm" src="https://user-images.githubusercontent.com/3143487/35205699-2a2ee934-feec-11e7-95f3-de55d9c568d5.png">
    </td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 56 19 pm" src="https://user-images.githubusercontent.com/3143487/35206081-e29c76b0-feee-11e7-81dd-0762ab663f77.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 55 48 pm" src="https://user-images.githubusercontent.com/3143487/35206083-e564fbc4-feee-11e7-857b-0d4ea7af718f.png">
    </td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 42 56 pm" src="https://user-images.githubusercontent.com/3143487/35205729-63b26cbc-feec-11e7-8cf0-fc0c072e47eb.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 39 49 pm" src="https://user-images.githubusercontent.com/3143487/35205731-66c98912-feec-11e7-96b9-9c0d97e26ed2.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center>enwiki > Brussels-Chapel railway station</td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 5 07 20 pm" src="https://user-images.githubusercontent.com/3143487/35178211-75e57a94-fd3b-11e7-96f1-52db66a6b577.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 4 33 22 pm" src="https://user-images.githubusercontent.com/3143487/35178212-79c73968-fd3b-11e7-9d74-9322998fc7e3.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center>enwiki > Greece</td>
  </tr>
  <tr>
    <td>
<img width="536" alt="screen shot 2018-01-23 at 12 24 09 pm" src="https://user-images.githubusercontent.com/3143487/35299029-dc35dea6-0038-11e8-9f0d-e8c7de5b1f47.png">
    </td>
    <td>
<img width="536" alt="screen shot 2018-01-23 at 10 37 07 am" src="https://user-images.githubusercontent.com/3143487/35299030-dc4c4db2-0038-11e8-8443-eb818357f785.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>protect against dupes</h3></td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 3 47 47 pm" src="https://user-images.githubusercontent.com/3143487/35177023-8b740b1e-fd31-11e7-8ce4-2c2cced82745.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 3 47 16 pm" src="https://user-images.githubusercontent.com/3143487/35177027-8f95c818-fd31-11e7-9cd6-0c5bdb104c86.png">
    </td>
  </tr>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>skip numbers-only</h3></td>
  </tr>
  <tr>
    <td colspan="2" align=center>enwiki > Lyublinsko–Dmitrovskaya line</td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 6 17 11 pm" src="https://user-images.githubusercontent.com/3143487/35178946-508f7ccc-fd45-11e7-87b8-a52ff746ad3e.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-21 at 8 50 12 pm" src="https://user-images.githubusercontent.com/3143487/35205788-bfad96fe-feec-11e7-82fb-b05584491bab.png">
    </td>
  </tr>
  <tr>
    <td colspan="2" align=center><h3>ensure text can always wrap correctly</h3></td>
  </tr>
  <tr>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 6 57 34 pm" src="https://user-images.githubusercontent.com/3143487/35179226-d2c1c880-fd4a-11e7-9462-669fa7559cf6.png">
    </td>
    <td>
<img width="431" alt="screen shot 2018-01-19 at 6 54 19 pm" src="https://user-images.githubusercontent.com/3143487/35179228-d66f54b6-fd4a-11e7-9b11-2ef0ea1a96c7.png">
    </td>
  </tr>
</table>


