### PR TITLE
Chore: rename NPM `dev` to `start`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 ### v4.9.1
 - Chore: replace Rollup.js bundler with Webpack; there are no anticipated client changes necessary but integrators should smoke test CSS and JavaScript functionality, especially on older devices, and app devs should verify their development workflows
+- Chore: rename NPM `dev` script to canonical `start`
 
 ### v4.9.0
 - New: consolidated 1st paragraph relocation transform

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pretest": "npm run -s build",
     "test": "mocha test/**/*.test.js",
     "serve:demo": "browser-sync start -c .browsersync.config.js",
-    "dev": "run-p -s serve:watch serve:demo",
+    "start": "run-p -s serve:watch serve:demo",
     "preversion": "[ -z \"$(git status -z)\" ]",
     "postversion": "git push --follow-tags origin HEAD && npm publish",
     "prepublish": "npm run -s lint:all && npm -s t",

--- a/readme.md
+++ b/readme.md
@@ -146,7 +146,7 @@ https://babeljs.io/docs/usage/caveats/#polyfills
 `npm run -s build:watch` will monitor and automatically rebuild the JavaScript and CSS bundles when files change. When used with NPM linking, this allows the app to always pull the latest local changes.
 
 ### Demo
-Demos are viewable by running `npm run -s dev` which also updates the browser instantly for changes.
+Demos are viewable by running `npm -s start` which also updates the browser instantly for changes.
 
 #### Adding new demo article
 Note: These are only used by the theme transform demo.


### PR DESCRIPTION
Rename the NPM `dev` script, which is the script most often used during
development to serve and iterate on the demos, to the canonical `start`.
This change makes the Page Library more like other JavaScript projects
and will decrease friction experienced by project newcomers.