### PR TITLE
Fix: edit pencil appearance

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v5.0.2
+- Fix: Changing the size of the edit pencil to make it look more compatible with other edit pencil views in the android app. Also ensure that the edit pencil has its own dedicated column space within the header element, to support display with multiline headings. 
+
 ### v5.0.1
 - Chore: replace Rollup.js bundler with Webpack; there are no anticipated client changes necessary but integrators should smoke test CSS and JavaScript functionality, especially on older devices, and app devs should verify their development workflows
 - Chore: rename NPM `dev` script to canonical `start`

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
-### v5.0.2
-- Fix: Changing the size of the edit pencil to make it look more compatible with other edit pencil views in the android app. Also ensure that the edit pencil has its own dedicated column space within the header element, to support display with multiline headings. 
+### v6.0.0
+- Breaking: update section header presentation for multiline titles; integration notes:
+  - Clients should now call EditTransform.newEditSectionHeader() instead of newEditSectionButton() and remove any custom code; please see JSDocs and demo
+- Update: change the size of the edit pencil to make it look more compatible with other edit pencil views in the android app
 
 ### v5.0.1
 - Chore: replace Rollup.js bundler with Webpack; there are no anticipated client changes necessary but integrators should smoke test CSS and JavaScript functionality, especially on older devices, and app devs should verify their development workflows

--- a/demo/EditTransform.html
+++ b/demo/EditTransform.html
@@ -30,16 +30,34 @@
 
     <div>
       <section>
-        <h2>Edit section 1</h2>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <h2 style="width: 100%; display: table;">
+          <span style="display: table-cell;">Edit section 1</span>
+        </h2>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
       </section>
       <section>
-        <h3>Edit section 2</h3>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <h3 style="width: 100%; display: table;">
+          <span style="display: table-cell;">Edit section 2</span>
+        </h3>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
       </section>
       <section>
-        <h4>Edit section 3</h4>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        <h4 style="width: 100%; display: table;">
+          <span style="display: table-cell;">Edit section 3</span>
+        </h4>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+        laborum.
       </section>
     </div>
 
@@ -48,7 +66,7 @@
       let index = 0
       document.querySelectorAll('h2, h3, h4').forEach(header => {
         const button = pagelib.EditTransform.newEditSectionButton(document, index)
-        header.parentNode.insertBefore(button, header)
+        header.appendChild(button)
         ++index
       })
     </script>

--- a/demo/EditTransform.html
+++ b/demo/EditTransform.html
@@ -29,46 +29,34 @@
     <control-panel></control-panel>
 
     <div>
-      <section>
-        <h2 style="width: 100%; display: table;">
-          <span style="display: table-cell;">Edit section 1</span>
-        </h2>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-      </section>
-      <section>
-        <h3 style="width: 100%; display: table;">
-          <span style="display: table-cell;">Edit section 2</span>
-        </h3>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-      </section>
-      <section>
-        <h4 style="width: 100%; display: table;">
-          <span style="display: table-cell;">Edit section 3</span>
-        </h4>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
-        magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-        pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
-        laborum.
-      </section>
     </div>
 
     <script>
       /* global pagelib */
+      // eslint-disable-next-line max-len
+      const contentHTML = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+      const titles = [
+        { level: 1, titleHTML: 'Edit section 1', contentHTML },
+        { level: 2, titleHTML: 'Edit section 2', contentHTML },
+        { level: 3, titleHTML: 'Edit section 3', contentHTML },
+        // eslint-disable-next-line max-len
+        { level: 2, titleHTML: 'A a B b C c D d E e F f G g H h I i J j K k L l M m N n O o P p Q q R r S s T t U u V v W w X x Y y Z z 0 1 2 3 4 5 6 7 8 9 ! @ # $ % ^ &amp; * ( ) - +', contentHTML }
+      ]
       let index = 0
-      document.querySelectorAll('h2, h3, h4').forEach(header => {
-        const button = pagelib.EditTransform.newEditSectionButton(document, index)
-        header.appendChild(button)
+      const root = document.querySelector('div')
+      for (const { level, titleHTML, contentHTML } of titles) {
+        const section = document.createElement('section')
+        const header = pagelib.EditTransform.newEditSectionHeader(document,
+          index, level, titleHTML)
+        section.appendChild(header)
+
+        const content = document.createElement('div')
+        content.innerHTML = contentHTML
+        section.appendChild(content)
+
+        root.appendChild(section)
         ++index
-      })
+      }
     </script>
 
 </body>

--- a/src/transform/EditTransform.css
+++ b/src/transform/EditTransform.css
@@ -4,8 +4,9 @@
 }
 
 .pagelib_edit_section_link_container {
-  margin: 2px 8px;
-  float: right;
+  margin: 2px 16px;
+  display: table-cell;
+  vertical-align: bottom;
   opacity: .54;
 }
 
@@ -34,10 +35,11 @@
 
 a.pagelib_edit_section_link {
   position: relative;
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
+  float: right;
   display: inline-block;
-  background-size: 28px 28px;
+  background-size: 24px 24px;
   background-repeat: no-repeat;
 
   background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgPGRlZnM+CiAgICA8cGF0aCBpZD0iYSIgZD0iTTMsMTcuMjQ3NSBMMywyMC45OTc1IEw2Ljc1LDIwLjk5NzUgTDE3LjgxNSw5LjkzMjUgTDE0LjA2NSw2LjE4MjUgTDMsMTcuMjQ3NSBaIE0yMC43MDUsNy4wNDI1IEMyMS4wOTUsNi42NTI1IDIxLjA5NSw2LjAxNzUgMjAuNzA1LDUuNjI3NSBMMTguMzcsMy4yOTI1IEMxNy45OCwyLjkwMjUgMTcuMzQ1LDIuOTAyNSAxNi45NTUsMy4yOTI1IEwxNS4xMjUsNS4xMjI1IEwxOC44NzUsOC44NzI1IEwyMC43MDUsNy4wNDI1IFoiLz4KICA8L2RlZnM+CiAgPGcgZmlsbD0ibm9uZSIgZmlsbC1ydWxlPSJldmVub2RkIj4KICAgIDx1c2UgZmlsbD0iIzAwMDAwMCIgeGxpbms6aHJlZj0iI2EiLz4KICA8L2c+Cjwvc3ZnPgo=);

--- a/src/transform/EditTransform.css
+++ b/src/transform/EditTransform.css
@@ -1,12 +1,22 @@
+.pagelib_edit_section_header {
+  display: flex;
+}
+
+.content-rtl .pagelib_edit_section_header {
+  flex-direction: row-reverse;
+}
+
+.pagelib_edit_section_title {
+  flex: 1;
+}
+
 #mainpage a.pagelib_edit_section_link,
 .no-editing a.pagelib_edit_section_link {
   display: none;
 }
 
 .pagelib_edit_section_link_container {
-  margin: 2px 16px;
-  display: table-cell;
-  vertical-align: bottom;
+  margin: 2px 8px;
   opacity: .54;
 }
 
@@ -28,7 +38,6 @@
 }
 
 .content-rtl .pagelib_edit_section_link_container {
-  float: left;
   -webkit-transform: scaleX( -1 );
   transform: scaleX( -1 );
 }
@@ -37,7 +46,6 @@ a.pagelib_edit_section_link {
   position: relative;
   width: 24px;
   height: 24px;
-  float: right;
   display: inline-block;
   background-size: 24px 24px;
   background-repeat: no-repeat;

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -1,7 +1,9 @@
 import './EditTransform.css'
 
 const CLASS = {
-  CONTAINER: 'pagelib_edit_section_link_container',
+  SECTION_HEADER: 'pagelib_edit_section_header',
+  TITLE: 'pagelib_edit_section_title',
+  LINK_CONTAINER: 'pagelib_edit_section_link_container',
   LINK: 'pagelib_edit_section_link',
   PROTECTION: { UNPROTECTED: '', PROTECTED: 'page-protected', FORBIDDEN: 'no-editing' }
 }
@@ -30,7 +32,7 @@ const newEditSectionLink = (document, index) => {
  */
 const newEditSectionButton = (document, index) => {
   const container = document.createElement('span')
-  container.classList.add(CLASS.CONTAINER)
+  container.classList.add(CLASS.LINK_CONTAINER)
 
   const link = newEditSectionLink(document, index)
   container.appendChild(link)
@@ -38,7 +40,32 @@ const newEditSectionButton = (document, index) => {
   return container
 }
 
+/**
+ * As a client, you may wish to set the ID attribute.
+ * @param {!Document} document
+ * @param {!number} index The zero-based index of the section.
+ * @param {!number} level The *one-based* header or table of contents level.
+ * @param {?string} titleHTML
+ * @return {!HTMLElement}
+ */
+const newEditSectionHeader = (document, index, level, titleHTML) => {
+  const element = document.createElement('div')
+  element.className = CLASS.SECTION_HEADER
+
+  const title = document.createElement(`h${level}`)
+  title.innerHTML = titleHTML || ''
+  title.className = CLASS.TITLE
+  title.setAttribute(DATA_ATTRIBUTE.SECTION_INDEX, index)
+  element.appendChild(title)
+
+  const button = newEditSectionButton(document, index)
+  element.appendChild(button)
+
+  return element
+}
+
 export default {
   CLASS,
-  newEditSectionButton
+  newEditSectionButton,
+  newEditSectionHeader
 }


### PR DESCRIPTION
**What Changed?**
-Changed edit pencil size from 28px to 24 px.
-Edit pencil now has its own table-cell space which floats to the right
-Edit container now aligns itself to the bottom

Screenshots for the change with different title lengths: https://drive.google.com/open?id=1sWwht34hLAVRYvnXa85CENnIQxOto4y-

Related Phabricator ticket: https://phabricator.wikimedia.org/T183018