### PR TITLE
Hide iOS edit pencils for sections H3 and above.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v6.0.1
+- Fix: hiding edit pencils on iOS for sections H3 to H6
+
 ### v6.0.0
 - Breaking: update section header presentation for multiline titles; integration notes:
   - Clients should now call EditTransform.newEditSectionHeader() instead of newEditSectionButton() and remove any custom code; please see JSDocs and demo

--- a/src/transform/EditTransform.css
+++ b/src/transform/EditTransform.css
@@ -94,9 +94,9 @@ a.pagelib_edit_section_link {
   background-color: #111;
 }
 
-.pagelib_platform_ios h3.section_heading span.pagelib_edit_section_link_container,
-.pagelib_platform_ios h4.section_heading span.pagelib_edit_section_link_container,
-.pagelib_platform_ios h5.section_heading span.pagelib_edit_section_link_container,
-.pagelib_platform_ios h6.section_heading span.pagelib_edit_section_link_container {
+.pagelib_platform_ios h3.pagelib_edit_section_title + span.pagelib_edit_section_link_container,
+.pagelib_platform_ios h4.pagelib_edit_section_title + span.pagelib_edit_section_link_container,
+.pagelib_platform_ios h5.pagelib_edit_section_title + span.pagelib_edit_section_link_container,
+.pagelib_platform_ios h6.pagelib_edit_section_title + span.pagelib_edit_section_link_container {
     display: none;
 }


### PR DESCRIPTION
6.0 changed the edit pencil containment a bit. Caused the CSS which hides iOS edit pencils on H3 and above to not behave itself.