### PR TITLE
Fix css regression

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v6.0.5
+- Fix: theme css regression. Collapsed table borders were missing for sepia and dark themes.
+
 ### v6.0.4
 - Update: update dependencies
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -55,7 +55,7 @@ const config = {
             loader: 'style-loader',
             options: { hmr: false }
           },
-          use: [{ loader: 'css-loader' }, 'postcss-loader']
+          use: [{ loader: 'css-loader', options: { minimize: false } }, 'postcss-loader']
         })
       }
     ]


### PR DESCRIPTION
Collapsed table borders were missing for sepia and dark themes.

See commit https://github.com/wikimedia/wikimedia-page-library/pull/137/commits/cb7be145bf2b43485b23c5f6a9c20b93680f82f2 message for details. ( caused by https://github.com/wikimedia/wikimedia-page-library/pull/134/commits/94003b970bb599dcf6606df730cd932ec93c3ccb )

# BEFORE:
<img width="431" alt="screen shot 2018-05-04 at 12 55 44 pm" src="https://user-images.githubusercontent.com/3143487/39649418-95131adc-4f9a-11e8-8f3c-69b4ec9385d3.png">


# AFTER:
<img width="431" alt="screen shot 2018-05-04 at 12 45 39 pm" src="https://user-images.githubusercontent.com/3143487/39649419-952c2856-4f9a-11e8-86c2-b7507bf31980.png">

