### PR TITLE
Second attempt to fix CSS regression.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+### v6.0.6
+- Fix: second attempt to fix theme css regression. v6.0.5 did not fix it.
+
 ### v6.0.5
 - Fix: theme css regression. Collapsed table borders were missing for sepia and dark themes.
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-html": "4.0.3",
     "eslint-plugin-jsdoc": "3.6.3",
     "eslint-plugin-json": "1.2.0",
-    "extract-text-webpack-plugin": "4.0.0-beta.0",
+    "mini-css-extract-plugin": "0.4.0",
     "mocha": "5.1.1",
     "npm-check-updates": "3.0.0-alpha.3",
     "npm-run-all": "4.1.2",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -2,7 +2,7 @@ import * as path from 'path'
 import * as pkg from './package.json'
 import * as webpack from 'webpack'
 import CleanPlugin from 'clean-webpack-plugin'
-import ExtractTextPlugin from 'extract-text-webpack-plugin'
+import MiniCssExtractPlugin from 'mini-css-extract-plugin'
 
 const PRODUCTION = process.env.NODE_ENV === 'production'
 
@@ -50,13 +50,10 @@ const config = {
       },
       {
         test: /\.css$/,
-        use: ExtractTextPlugin.extract({
-          fallback: {
-            loader: 'style-loader',
-            options: { hmr: false }
-          },
-          use: [{ loader: 'css-loader', options: { minimize: false } }, 'postcss-loader']
-        })
+        use: [
+          MiniCssExtractPlugin.loader,
+          { loader: 'css-loader', options: { minimize: false } }
+        ]
       }
     ]
   },
@@ -80,7 +77,7 @@ const config = {
       },
       VERSION: JSON.stringify(pkg.version)
     }),
-    new ExtractTextPlugin({ filename: '[name].css' })
+    new MiniCssExtractPlugin({ filename: '[name].css' })
   ]
 }
 


### PR DESCRIPTION
6.0.5 (https://github.com/wikimedia/wikimedia-page-library/pull/137) fixed the CSS regression when developing locally, but when 6.0.5 was published the `CollapseTable` css again jumped above the `ThemeTransform` css. Based on the information below I suspect `extract-text-webpack-plugin` is at fault.

So this PR uses `mini-css-extract-plugin` instead of `extract-text-webpack-plugin`, per the recommendations in the comments linked below.

-----
>How can I keep the css order in the css file when I use extract-text-webpack-plugin？

https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/200

>...extract-text-webpack-plugin is for webpack3 and older (will not support webpack 4 it seems). They say to move to mini-css-extract-plugin...

https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/200#issuecomment-374860248

> The webpack >= v4.0.0 'support' for extract-text-webpack-plugin was moved to mini-css-extract-plugin as more lightweight approach for webpack >= v4.0.0 and ETWP entered maintenance mode. We are sorry for the inconvenience here, but ETWP reached a point where maintaining it become too much of a burden and it's not the first time upgrading a major webpack version was complicated and cumbersome due to issues with ETWP. The mid-term plan is integrate CSS support directly into webpack to avoid this kind of issue in the future

https://github.com/webpack-contrib/extract-text-webpack-plugin/issues/701#issuecomment-374551300
