### PR TITLE
Fix: generate source maps for debug builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html",
     "lint:all": "npm run -s lint .",
     "build": "NODE_ENV=production webpack -p",
-    "build:watch": "webpack -dw",
+    "build:watch": "webpack -dw --devtool source-map",
     "serve:watch": "webpack-dev-server -dw",
     "test:size": "bundlesize",
     "pretest": "npm run -s build",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -63,7 +63,7 @@ const config = {
 
   stats: STATS,
 
-  devtool: PRODUCTION ? 'source-map' : 'cheap-module-eval-source-map',
+  devtool: 'source-map',
 
   devServer: PRODUCTION ? undefined : {
     clientLogLevel: 'warning',


### PR DESCRIPTION
Source maps were not generated for debug builds. There seem to be two
issues:

  - The setting in the Webpack configuration file does not appear to be
    used. It must be specified on the command line.

  - cheap-module-eval-source-map doesn't seem to work so use the same
    thing as prod, source-map.