### PR TITLE
Make the edit pencil in section titles optional.

### DIFF
--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -45,10 +45,11 @@ const newEditSectionButton = (document, index) => {
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
  * @param {!number} level The *one-based* header or table of contents level.
- * @param {?string} titleHTML
+ * @param {?string} titleHTML Title of this section header.
+ * @param {?boolean} showEditPencil Whether to show the "edit" pencil (default is true).
  * @return {!HTMLElement}
  */
-const newEditSectionHeader = (document, index, level, titleHTML) => {
+const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil = true) => {
   const element = document.createElement('div')
   element.className = CLASS.SECTION_HEADER
 
@@ -58,8 +59,10 @@ const newEditSectionHeader = (document, index, level, titleHTML) => {
   title.setAttribute(DATA_ATTRIBUTE.SECTION_INDEX, index)
   element.appendChild(title)
 
-  const button = newEditSectionButton(document, index)
-  element.appendChild(button)
+  if (showEditPencil) {
+    const button = newEditSectionButton(document, index)
+    element.appendChild(button)
+  }
 
   return element
 }

--- a/test/transform/EditTransform.test.js
+++ b/test/transform/EditTransform.test.js
@@ -62,4 +62,22 @@ describe('EditTransform', () => {
       assert.equal(element.childNodes.item(0).nodeName, 'H4')
     })
   })
+
+  describe('.newEditSectionHeader(0, 2, false)', () => {
+    let document
+    let element
+
+    beforeEach(() => {
+      document = fixtureIO.documentFromFixtureFile('EditTransform.html')
+      element = editTransform.newEditSectionHeader(document, 0, 2, 'Title', false)
+    })
+
+    it('creates h2 element', () => {
+      assert.equal(element.childNodes.item(0).nodeName, 'H2')
+    })
+    it('does not have edit container or pencil', () => {
+      assert.ok(!element.innerHTML.includes('pagelib_edit_section_link'))
+      assert.ok(!element.innerHTML.includes('pagelib_edit_section_link_container'))
+    })
+  })
 })


### PR DESCRIPTION
In certain cases, we don't actually want specific sections to be editable (whether due to template transclusion, Parsoid oddities, etc), so we'd like to be able to optionally show or hide the edit pencil when building the section header element.