### PR TITLE
LazyLoadTransformer now can handle existing placeholders

### DIFF
--- a/src/transform/LazyLoadTransform.ts
+++ b/src/transform/LazyLoadTransform.ts
@@ -165,6 +165,7 @@ const loadPlaceholder = (document: Document, placeholder: HTMLSpanElement): HTML
 }
 
 export default {
+  PLACEHOLDER_CLASS,
   queryLazyLoadableImages,
   convertImagesToPlaceholders,
   loadPlaceholder

--- a/src/transform/LazyLoadTransformer.js
+++ b/src/transform/LazyLoadTransformer.js
@@ -42,6 +42,19 @@ export default class {
   }
 
   /**
+   * Searches for existing placeholders in the DOM Document.
+   * This is an alternative to #convertImagesToPlaceholders if that was already done server-side.
+   * @param {!Element} element root element to start searching for placeholders
+   * @return {void}
+   */
+  collectExistingPlaceholders(element) {
+    const placeholders
+      = Array.from(element.querySelectorAll(`.${LazyLoadTransform.PLACEHOLDER_CLASS}`))
+    this._placeholders = this._placeholders.concat(placeholders)
+    this._register()
+  }
+
+  /**
    * Manually trigger a load images check. Calling this function may deregister this instance from
    * listening to page events.
    * @return {void}


### PR DESCRIPTION
Adds a new method LazyLoadTransformer.collectExistingPlaceholders which
should be used instead of `convertImagesToPlaceholders` if the
placeholders have been created server-side.

The new method `convertImagesToPlaceholders` looks for elements with the placeholder class.
No need to call `convertImagesToPlaceholders`.

Bug: https://phabricator.wikimedia.org/T198668