### PR TITLE
Chore: upgrade Domino v2.0.2 →  2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3381,9 +3381,9 @@
       }
     },
     "domino": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.0.2.tgz",
-      "integrity": "sha512-vzykUakUw5s1p0RrN/vI2sShYo3pLRy/z7PM1PuOIZIlMOJ0XfOnrckGE5f4MxIQVe5XcrH7yG9mR+l77mgLVA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.0.3.tgz",
+      "integrity": "sha512-QkW2THVtKJw9FmV6awFQbcpaJPIqQtF+F1PMO5EXIdULVit9IaU3w+ZQgBjrR6hSHgP97TKyo/tcFqkgwfYenA==",
       "dev": true
     },
     "domutils": {
@@ -4539,14 +4539,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4566,8 +4564,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4715,7 +4712,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "bundlesize": "0.17.0",
     "clean-webpack-plugin": "0.1.19",
     "css-loader": "0.28.11",
-    "domino": "2.0.2",
+    "domino": "2.0.3",
     "eslint": "4.19.1",
     "eslint-config-node-services": "2.2.5",
     "eslint-config-wikimedia": "github:wikimedia/eslint-config-wikimedia#292cf3c",

--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -27,9 +27,7 @@ const isWhitespaceTextNode = node =>
  */
 const hasCitationLink = element => {
   const anchor = element.querySelector('a')
-  // todo: use anchor.hash when https://github.com/fgnass/domino/issues/127 is
-  //       fixed.
-  return anchor && isCitation(anchor.getAttribute('href'))
+  return anchor && isCitation(anchor.hash)
 }
 
 /**

--- a/test/transform/CompatibilityTransform.test.js
+++ b/test/transform/CompatibilityTransform.test.js
@@ -7,7 +7,7 @@ describe('CompatibilityTransform', () => {
     const document = domino.createDocument()
     pagelib.CompatibilityTransform.enableSupport(document)
     for (const value of Object.values(pagelib.CompatibilityTransform.COMPATIBILITY)) {
-      assert.ok(document.querySelector('html').classList.contains(value))
+      assert.ok(!document.querySelector('html').classList.contains(value), value)
     }
   })
 })

--- a/test/transform/WidenImage.test.js
+++ b/test/transform/WidenImage.test.js
@@ -124,12 +124,12 @@ describe('WidenImage', () => {
       const doc = domino.createDocument()
       const element = doc.createElement('div')
       element.style.width = ''
-      element.style.float = undefined
+      element.style.float = ''
       updateExistingStyleValue(element.style, 'width', '100%')
       updateExistingStyleValue(element.style, 'float', 'left')
       updateExistingStyleValue(element.style, 'maxWidth', '25%')
       assert.equal(element.style.width, '')
-      assert.equal(element.style.float, undefined)
+      assert.equal(element.style.float, '')
       assert.equal(element.style.maxWidth, '')
     })
   })


### PR DESCRIPTION
Upgrade Domino to v2.0.3. This release includes a fix for URL fragments
which this patch removes a workaround for. Additionally, CSS filters are
now supported by Domino so the CompatibilityTransform test is inverted,
and Element.style.<property> now correctly unconditionally returns an
empty string when undefined so the WidenImage test is updated.

https://github.com/fgnass/domino/issues/127
https://github.com/fgnass/domino/blob/88309f8/CHANGELOG.md#domino-203-12-jul-2018