### PR TITLE
Avoid infobox too narrow issue

### DIFF
--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -172,3 +172,11 @@ div.pagelib_collapse_table_container {
 .pagelib_collapse_table_icon {
   box-sizing: border-box;
 }
+
+/* Avoid infobox too narrow issue, see https://phabricator.wikimedia.org/T201381,
+   undoing some of https://gerrit.wikimedia.org/r/c/mediawiki/skins/MinervaNeue/+/428868
+   but only for tables we collapse. */
+.pagelib_collapse_table_container table {
+    display: block;
+    width: 100% !important
+}


### PR DESCRIPTION
This change undoes some of
https://gerrit.wikimedia.org/r/c/mediawiki/skins/MinervaNeue/+/428868
but only for tables we collapse, and therefore don't float.

QA: Turn on Collapse tables and compare expanded infoboxes in:
http://localhost:3000/ThemeTransform.html#en.Chris%20Cornell.793305307.MCS.json
http://localhost:3000/ThemeTransform.html#en.Cat.792971769.MCS.json

Bug: https://phabricator.wikimedia.org/T201381