### PR TITLE
Remove citation styles

### DIFF
--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -67,7 +67,7 @@ const collectRefText = (document, source) => {
     .filter(NodeUtilities.isNodeTypeElementOrText)
     .forEach(cloneNodeIntoFragmentDiv)
 
-  const removalSelector = 'sup[id^=cite_ref], .mw-cite-backlink'
+  const removalSelector = 'style, sup[id^=cite_ref], .mw-cite-backlink'
   Polyfill.querySelectorAll(fragDiv, removalSelector)
     .forEach(node => node.remove())
 

--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -67,7 +67,7 @@ const collectRefText = (document, source) => {
     .filter(NodeUtilities.isNodeTypeElementOrText)
     .forEach(cloneNodeIntoFragmentDiv)
 
-  const removalSelector = 'style, sup[id^=cite_ref], .mw-cite-backlink'
+  const removalSelector = 'link, style, sup[id^=cite_ref], .mw-cite-backlink'
   Polyfill.querySelectorAll(fragDiv, removalSelector)
     .forEach(node => node.remove())
 

--- a/test/transform/ReferenceCollection.test.js
+++ b/test/transform/ReferenceCollection.test.js
@@ -17,6 +17,7 @@ const referenceGroupHTML = `
   <span id='cite_note-d'>9 10 11
     <sup id='cite_ref-d'>tick</sup>
     <a class='mw-cite-backlink'>link</a>
+    <style>.mw-parser-output cite.citation{font-style:inherit}</style>
   </span>
 `
 
@@ -221,12 +222,12 @@ describe('ReferenceCollection', () => {
       const referenceText = collectRefText(document, document.querySelector('#cite_ref-b'))
       assert.strictEqual(referenceText, '3 4 5')
     })
-    it('removes `sup[id^=cite_ref], .mw-cite-backlink` elements from reference text', () => {
+    it('removes `style, sup[id^=cite_ref], .mw-cite-backlink` elements from reference text', () => {
       const referenceText = collectRefText(document, document.querySelector('#cite_ref-d'))
 
       document = domino.createDocument(referenceText)
 
-      const removalSelector = 'sup[id^=cite_ref], .mw-cite-backlink'
+      const removalSelector = 'style, sup[id^=cite_ref], .mw-cite-backlink'
       const matches = document.querySelectorAll(removalSelector)
 
       assert.strictEqual(matches.length, 0)

--- a/test/transform/ReferenceCollection.test.js
+++ b/test/transform/ReferenceCollection.test.js
@@ -18,6 +18,7 @@ const referenceGroupHTML = `
     <sup id='cite_ref-d'>tick</sup>
     <a class='mw-cite-backlink'>link</a>
     <style>.mw-parser-output cite.citation{font-style:inherit}</style>
+    <link rel='stylesheet' href='//foo.bar'/>
   </span>
 `
 
@@ -222,12 +223,12 @@ describe('ReferenceCollection', () => {
       const referenceText = collectRefText(document, document.querySelector('#cite_ref-b'))
       assert.strictEqual(referenceText, '3 4 5')
     })
-    it('removes `style, sup[id^=cite_ref], .mw-cite-backlink` elements from reference text', () => {
+    it('removes specified elements from reference text', () => {
       const referenceText = collectRefText(document, document.querySelector('#cite_ref-d'))
 
       document = domino.createDocument(referenceText)
 
-      const removalSelector = 'style, sup[id^=cite_ref], .mw-cite-backlink'
+      const removalSelector = 'link, style, sup[id^=cite_ref], .mw-cite-backlink'
       const matches = document.querySelectorAll(removalSelector)
 
       assert.strictEqual(matches.length, 0)


### PR DESCRIPTION
The reference text collected in ReferenceCollection.js has begun to
improperly include styles included via TemplateStyles, and these are now
being displayed to users in the Android app.

This patch adds 'style' to the list of selectors to strip when compiling
the reference text.

Bug: https://phabricator.wikimedia.org/T206527