### PR TITLE
Add Header Transform

### DIFF
--- a/demo/HeaderTransform.html
+++ b/demo/HeaderTransform.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang=en>
+
+  <head>
+    <meta charset=utf-8>
+    <title>HeaderTransform</title>
+    <link href=http://localhost:8080/wikimedia-page-library-transform.css rel=stylesheet>
+    <style>
+      :root {
+        --control-panel-layout-direction-visibility: visible;
+        --control-panel-theme-visibility: visible;
+      }
+      a {
+        text-decoration: none;
+      }
+      div {
+        max-width: 380px;
+        margin: 0 auto;
+
+        /* Mimic the constraints of a physical screen by preventing box shadows from spilling out. */
+        overflow: hidden;
+      }
+    </style>
+    <script src=https://polygit.org/components/webcomponentsjs/webcomponents-loader.js></script>
+    <script src=http://localhost:8080/wikimedia-page-library-transform.js></script>
+    <link rel=import href=ControlPanel.html>
+  </head>
+
+  <body>
+    <control-panel></control-panel>
+    <div id=headerGoesHere></div>
+
+    <script>
+      /* global pagelib */
+      const container = document.querySelector('#headerGoesHere')
+
+      const configurations = [{
+        displayTitle: 'Ice cream',
+        descriptionEditable: true,
+        description: 'frozen food',
+        hasPronunciation: true,
+        isMainPage: false
+      }, {
+        displayTitle: 'Add a description',
+        descriptionEditable: true,
+        description: '',
+        hasPronunciation: false,
+        isMainPage: false
+      }, {
+        displayTitle: 'No description',
+        descriptionEditable: false,
+        description: '',
+        hasPronunciation: false,
+        isMainPage: false
+      }, {
+        displayTitle: 'Main page',
+        descriptionEditable: false,
+        hasPronunciation: false,
+        isMainPage: true
+      }]
+
+      /**
+       * @return {boolean} true if page is in right-to-left mode
+       */
+      const isRtl = () => document.querySelector('html').classList.contains('content-rtl')
+
+      /**
+       * @return {boolean} true if dark or black theme is used
+       */
+      const isDarkMode = () => {
+        const classList = document.querySelector('html').classList
+        return classList.contains('pagelib_theme_dark') || classList.contains('pagelib_theme_black')
+      }
+
+      configurations.forEach(configuration => {
+        const p = document.createElement('p')
+        p.innerHTML = `Example header for "${configuration.displayTitle}":`
+        container.appendChild(p)
+        pagelib.HeaderTransform.add(document, container, configuration.displayTitle,
+          configuration.descriptionEditable, configuration.description, 'Add a description',
+          configuration.hasPronunciation, configuration.isMainPage, isRtl(),
+          isDarkMode())
+      })
+    </script>
+  </body>
+
+</html>

--- a/demo/HeaderTransform.html
+++ b/demo/HeaderTransform.html
@@ -64,22 +64,13 @@
        */
       const isRtl = () => document.querySelector('html').classList.contains('content-rtl')
 
-      /**
-       * @return {boolean} true if dark or black theme is used
-       */
-      const isDarkMode = () => {
-        const classList = document.querySelector('html').classList
-        return classList.contains('pagelib_theme_dark') || classList.contains('pagelib_theme_black')
-      }
-
       configurations.forEach(configuration => {
         const p = document.createElement('p')
         p.innerHTML = `Example header for "${configuration.displayTitle}":`
         container.appendChild(p)
         pagelib.HeaderTransform.add(document, container, configuration.displayTitle,
           configuration.descriptionEditable, configuration.description, 'Add a description',
-          configuration.hasPronunciation, configuration.isMainPage, isRtl(),
-          isDarkMode())
+          configuration.hasPronunciation, configuration.isMainPage, isRtl())
       })
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     },
     {
       "path": "build/wikimedia-page-library-transform.css",
-      "maxSize": "26.0KB"
+      "maxSize": "26.3KB"
     },
     {
       "path": "build/wikimedia-page-library-transform.js",

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -12,12 +12,6 @@ const DATA_ATTRIBUTE = { SECTION_INDEX: 'data-id', ACTION: 'data-action' }
 const ACTION_EDIT_SECTION = 'edit_section'
 
 /**
- * @param {!Element} element
- * @return {!HTMLAnchorElement}
- */
-const queryEditSectionLink = element => element.querySelector(`.${CLASS.LINK}`)
-
-/**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLAnchorElement}
@@ -75,7 +69,6 @@ const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil 
 
 export default {
   CLASS,
-  queryEditSectionLink,
   newEditSectionButton,
   newEditSectionHeader
 }

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -12,6 +12,12 @@ const DATA_ATTRIBUTE = { SECTION_INDEX: 'data-id', ACTION: 'data-action' }
 const ACTION_EDIT_SECTION = 'edit_section'
 
 /**
+ * @param {!Element} element
+ * @return {!HTMLAnchorElement}
+ */
+const queryEditSectionLink = element => element.querySelector(`.${CLASS.LINK}`)
+
+/**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLAnchorElement}
@@ -69,6 +75,7 @@ const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil 
 
 export default {
   CLASS,
+  queryEditSectionLink,
   newEditSectionButton,
   newEditSectionHeader
 }

--- a/src/transform/HeaderTransform.css
+++ b/src/transform/HeaderTransform.css
@@ -35,7 +35,7 @@ html[dir='rtl'] .pagelib_header_description svg,
   font-style: italic;
 }
 
-.pagelib_divider {
+.pagelib_header_divider {
   width: 56px;
   border-top: 1px solid currentColor !important;
   margin-top: 12px;
@@ -44,7 +44,7 @@ html[dir='rtl'] .pagelib_header_description svg,
 
 .pagelib_edit_section_link,
 .pagelib_header_description,
-.pagelib_divider {
+.pagelib_header_divider {
   opacity: 0.7;
 }
 
@@ -52,8 +52,8 @@ html[dir='rtl'] .pagelib_header_description svg,
 .pagelib_theme_black .pagelib_edit_section_link,
 .pagelib_theme_dark .pagelib_header_description,
 .pagelib_theme_black .pagelib_header_description,
-.pagelib_theme_dark .pagelib_divider,
-.pagelib_theme_black .pagelib_divider {
+.pagelib_theme_dark .pagelib_header_divider,
+.pagelib_theme_black .pagelib_header_divider {
   opacity: 0.54;
 }
 

--- a/src/transform/HeaderTransform.css
+++ b/src/transform/HeaderTransform.css
@@ -14,8 +14,8 @@ html[dir='rtl'] .pagelib_header .pagelib_edit_section_link,
   fill: currentColor;
 }
 
-html[dir='rtl'] .pagelib_edit_section_link,
-.content-rtl .pagelib_edit_section_link,
+html[dir='rtl'] .pagelib_header .pagelib_edit_section_link,
+.content-rtl .pagelib_header .pagelib_edit_section_link,
 html[dir='rtl'] .pagelib_header_pronunciation svg,
 .content-rtl .pagelib_header_pronunciation svg,
 html[dir='rtl'] .pagelib_header_description svg,
@@ -42,22 +42,14 @@ html[dir='rtl'] .pagelib_header_description svg,
   margin-bottom: 16px;
 }
 
-.pagelib_edit_section_link,
 .pagelib_header_description,
 .pagelib_header_divider {
   opacity: 0.7;
 }
 
-.pagelib_theme_dark .pagelib_edit_section_link,
-.pagelib_theme_black .pagelib_edit_section_link,
 .pagelib_theme_dark .pagelib_header_description,
 .pagelib_theme_black .pagelib_header_description,
 .pagelib_theme_dark .pagelib_header_divider,
 .pagelib_theme_black .pagelib_header_divider {
   opacity: 0.54;
-}
-
-.pagelib_theme_dark .pagelib_edit_section_link,
-.pagelib_theme_black .pagelib_edit_section_link {
-  -webkit-filter: invert(100%);
 }

--- a/src/transform/HeaderTransform.css
+++ b/src/transform/HeaderTransform.css
@@ -8,7 +8,7 @@ html[dir='rtl'] .pagelib_header .pagelib_edit_section_link,
   float: left;
 }
 
-.pagelib_pronunciation svg,
+.pagelib_header_pronunciation svg,
 .pagelib_header_description svg {
   vertical-align: middle;
   fill: currentColor;
@@ -16,8 +16,8 @@ html[dir='rtl'] .pagelib_header .pagelib_edit_section_link,
 
 html[dir='rtl'] .pagelib_edit_section_link,
 .content-rtl .pagelib_edit_section_link,
-html[dir='rtl'] .pagelib_pronunciation svg,
-.content-rtl .pagelib_pronunciation svg,
+html[dir='rtl'] .pagelib_header_pronunciation svg,
+.content-rtl .pagelib_header_pronunciation svg,
 html[dir='rtl'] .pagelib_header_description svg,
 .content-rtl .pagelib_header_description svg {
   transform: scaleX(-1);
@@ -27,7 +27,7 @@ html[dir='rtl'] .pagelib_header_description svg,
   font-size: 90%;
 }
 
-.pagelib_pronunciation {
+.pagelib_header_pronunciation {
   color: inherit;
 }
 

--- a/src/transform/HeaderTransform.css
+++ b/src/transform/HeaderTransform.css
@@ -1,0 +1,63 @@
+.pagelib_edit_section_link {
+  float: right;
+}
+
+/* todo: standardize on RTL selectors throughout the codebase. In many places we use .content-rtl. */
+html[dir='rtl'] .pagelib_edit_section_link,
+.content-rtl .pagelib_edit_section_link {
+  float: left;
+}
+
+.pagelib_pronunciation svg,
+.pagelib_header_description svg {
+  vertical-align: middle;
+  fill: currentColor;
+}
+
+html[dir='rtl'] .pagelib_edit_section_link,
+.content-rtl .pagelib_edit_section_link,
+html[dir='rtl'] .pagelib_pronunciation svg,
+.content-rtl .pagelib_pronunciation svg,
+html[dir='rtl'] .pagelib_header_description svg,
+.content-rtl .pagelib_header_description svg {
+  transform: scaleX(-1);
+}
+
+.pagelib_header_description {
+  font-size: 90%;
+}
+
+.pagelib_pronunciation {
+  color: inherit;
+}
+
+.pagelib_header_description a {
+  font-style: italic;
+}
+
+.pagelib_divider {
+  width: 56px;
+  border-top: 1px solid currentColor !important;
+  margin-top: 12px;
+  margin-bottom: 16px;
+}
+
+.pagelib_edit_section_link,
+.pagelib_header_description,
+.pagelib_divider {
+  opacity: 0.7;
+}
+
+.pagelib_theme_dark .pagelib_edit_section_link,
+.pagelib_theme_black .pagelib_edit_section_link,
+.pagelib_theme_dark .pagelib_header_description,
+.pagelib_theme_black .pagelib_header_description,
+.pagelib_theme_dark .pagelib_divider,
+.pagelib_theme_black .pagelib_divider {
+  opacity: 0.54;
+}
+
+.pagelib_theme_dark .pagelib_edit_section_link,
+.pagelib_theme_black .pagelib_edit_section_link {
+  -webkit-filter: invert(100%);
+}

--- a/src/transform/HeaderTransform.css
+++ b/src/transform/HeaderTransform.css
@@ -1,10 +1,10 @@
-.pagelib_edit_section_link {
+.pagelib_header .pagelib_edit_section_link {
   float: right;
 }
 
 /* todo: standardize on RTL selectors throughout the codebase. In many places we use .content-rtl. */
-html[dir='rtl'] .pagelib_edit_section_link,
-.content-rtl .pagelib_edit_section_link {
+html[dir='rtl'] .pagelib_header .pagelib_edit_section_link,
+.content-rtl .pagelib_header .pagelib_edit_section_link {
   float: left;
 }
 

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -48,7 +48,7 @@ const makePronunciationIcon = document => {
 const makeDescriptionDiv = (document, isDescriptionEditable, description, stringAddDescription) => {
   const descriptionDiv = document.createElement('div')
   const editButton = EditTransform.newEditSectionButton(document, 0)
-  const mainEditPencilAnchor = EditTransform.queryEditSectionLink(editButton)
+  const mainEditPencilAnchor = editButton.querySelector('a')
   if (isDescriptionEditable) {
     mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
   }

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -112,7 +112,7 @@ const add = (document, container, displayTitle, descriptionEditable, description
 
   // Decorative divider that appears below the title and description
   const dividerLine = document.createElement('div')
-  dividerLine.setAttribute('class', 'pagelib_divider')
+  dividerLine.setAttribute('class', 'pagelib_header_divider')
 
   if (!isMainPage) {
     titleDiv.appendChild(h1)

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -1,27 +1,24 @@
-const OPACITY_LIGHT = 0.54
-const OPACITY_DARK = 0.7
+import './HeaderTransform.css'
 
 /**
  * Makes an SVG element.
  * @param {!Document} document
  * @param {!number} width
  * @param {!number}height
- * @param {!string} color
  * @param {!string} svgContents
  * @return {!Element}
  */
-const makeSvgElement = (document, width, height, color, svgContents) => {
+const makeSvgElement = (document, width, height, svgContents) => {
   const svg = document.createElement('svg')
   svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
   svg.setAttribute('width', width)
   svg.setAttribute('height', height)
-  svg.setAttribute('style', `vertical-align:middle;fill:${color};`)
   svg.innerHTML = svgContents
   return svg
 }
 
 /**
- * Add header with title, pronunciation button, and description.
+ * Adds page header with title, pronunciation button, and description.
  * @param {!Document} document
  * @param {!Element} container
  * @param {!string} displayTitle
@@ -49,16 +46,14 @@ const add = (document, container, displayTitle, descriptionEditable, description
 
   if (hasPronunciation) {
     // Create and append the audio "speaker" icon
-    const audioIcon = makeSvgElement(document, 16, 16, 'currentColor',
+    const audioIcon = makeSvgElement(document, 16, 16,
       // eslint-disable-next-line max-len
       '<path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path><path d="M0 0h24v24H0z" fill="none"></path>')
     audioIcon.setAttribute('viewBox', '0 0 24 24')
     audioIcon.style.margin = '0 6px 2px 6px'
-    if (isRtl) {
-      audioIcon.style.transform = 'scaleX(-1)'
-    }
     const audioAnchor = document.createElement('a')
     audioAnchor.setAttribute('data-action', 'pronunciation_click')
+    audioAnchor.setAttribute('class', 'pagelib_pronunciation')
     audioAnchor.setAttribute('style', 'color:inherit;')
     audioAnchor.innerHTML = audioIcon.outerHTML
     h1.appendChild(audioAnchor)
@@ -69,30 +64,21 @@ const add = (document, container, displayTitle, descriptionEditable, description
   const mainEditPencilAnchor = document.createElement('a')
   mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
   mainEditPencilAnchor.setAttribute('class', 'pagelib_edit_section_link')
-  let style = isDarkMode ? 'filter:invert(100%);-webkit-filter:invert(100%);' : ''
-  style += isRtl ? 'float:left;transform:scaleX(-1);' : 'float:right;'
-  mainEditPencilAnchor.setAttribute('style', style)
-  mainEditPencilAnchor.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
 
   // Span that will contain the description and/or the two-line icon
   const descriptionSpan = document.createElement('span')
-  descriptionSpan.setAttribute('style', 'font-size:90%;')
+  descriptionSpan.setAttribute('class', 'pagelib_header_description')
   if (description) {
     descriptionSpan.innerHTML = description
-    descriptionSpan.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
   } else if (descriptionEditable) {
     const descriptionAnchor = document.createElement('a')
-    const descSvg = makeSvgElement(document, 24, 16, 'currentColor',
+    const descSvg = makeSvgElement(document, 24, 16,
       // eslint-disable-next-line max-len
       '<defs><path id="a" d="M0 0h24v24H0V0z"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path d="M4 9h16v2H4zm0 4h10v2H4z" clip-path="url(#b)"/>')
     descSvg.setAttribute('viewBox', '4 9 24 8')
-    if (isRtl) {
-      descSvg.style.transform = 'scaleX(-1)'
-    }
     descriptionAnchor.setAttribute('href', '#')
     descriptionAnchor.setAttribute('data-action', 'edit_description')
     descriptionAnchor.innerHTML = descSvg.outerHTML + stringAddDescription
-    descriptionAnchor.setAttribute('style', 'font-style:italic;')
     descriptionSpan.appendChild(descriptionAnchor)
   } else {
     descriptionSpan.innerHTML = ' '
@@ -100,9 +86,7 @@ const add = (document, container, displayTitle, descriptionEditable, description
 
   // Decorative divider that appears below the title and description
   const dividerLine = document.createElement('div')
-  dividerLine.setAttribute('style',
-    'width:56px;border-top: 1px solid currentColor !important;margin-top:12px;margin-bottom:16px;')
-  dividerLine.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
+  dividerLine.setAttribute('class', 'pagelib_divider')
 
   descriptionDiv.appendChild(mainEditPencilAnchor)
   descriptionDiv.appendChild(descriptionSpan)

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -95,7 +95,7 @@ const add = (document, container, displayTitle, descriptionEditable, description
   const titleDiv = document.createElement('div')
   titleDiv.id = 'heading_0'
   titleDiv.setAttribute('data-id', 0)
-  titleDiv.className = 'section_heading'
+  titleDiv.className = 'section_heading pagelib_header'
   titleDiv.setAttribute('dir', isRtl ? 'rtl' : 'ltr')
 
   // Create the actual H1 heading

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -1,4 +1,5 @@
 import './HeaderTransform.css'
+import EditTransform from './EditTransform.js'
 
 /**
  * Makes an SVG element.
@@ -37,7 +38,7 @@ const makePronunciationIcon = document => {
 }
 
 /**
- * Makes a div including whatever is needed to display the description.
+ * Makes a div including whatever is needed to display the description and edit button.
  * @param {!Document} document
  * @param {boolean} descriptionEditable
  * @param {?string} description
@@ -46,9 +47,11 @@ const makePronunciationIcon = document => {
  */
 const makeDescriptionDiv = (document, descriptionEditable, description, stringAddDescription) => {
   const descriptionDiv = document.createElement('div')
-  const mainEditPencilAnchor = document.createElement('a')
-  mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
-  mainEditPencilAnchor.setAttribute('class', 'pagelib_edit_section_link')
+  const editButton = EditTransform.newEditSectionButton(document, 0)
+  const mainEditPencilAnchor = EditTransform.queryEditSectionLink(editButton)
+  if (descriptionEditable) {
+    mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
+  }
 
   // Span that will contain the description and/or the two-line icon
   const descriptionSpan = document.createElement('span')
@@ -68,8 +71,8 @@ const makeDescriptionDiv = (document, descriptionEditable, description, stringAd
   } else {
     descriptionSpan.innerHTML = ' '
   }
-  descriptionDiv.appendChild(mainEditPencilAnchor)
   descriptionDiv.appendChild(descriptionSpan)
+  descriptionDiv.appendChild(editButton)
   return descriptionDiv
 }
 

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -18,6 +18,62 @@ const makeSvgElement = (document, width, height, svgContents) => {
 }
 
 /**
+ * Makes the audio "speaker" icon for the pronunciation of the page title
+ * @param {!Document} document
+ * @return {!Element}
+ */
+const makePronunciationIcon = document => {
+  const audioIcon = makeSvgElement(document, 16, 16,
+    // eslint-disable-next-line max-len
+    '<path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path><path d="M0 0h24v24H0z" fill="none"></path>')
+  audioIcon.setAttribute('viewBox', '0 0 24 24')
+  audioIcon.style.margin = '0 6px 2px 6px'
+  const audioAnchor = document.createElement('a')
+  audioAnchor.setAttribute('data-action', 'pronunciation_click')
+  audioAnchor.setAttribute('class', 'pagelib_pronunciation')
+  audioAnchor.setAttribute('style', 'color:inherit;')
+  audioAnchor.innerHTML = audioIcon.outerHTML
+  return audioAnchor
+}
+
+/**
+ * Makes a div including whatever is needed to display the description.
+ * @param {!Document} document
+ * @param {boolean} descriptionEditable
+ * @param {?string} description
+ * @param {!string} stringAddDescription for I18N
+ * @return {!Element}
+ */
+const makeDescriptionDiv = (document, descriptionEditable, description, stringAddDescription) => {
+  const descriptionDiv = document.createElement('div')
+  const mainEditPencilAnchor = document.createElement('a')
+  mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
+  mainEditPencilAnchor.setAttribute('class', 'pagelib_edit_section_link')
+
+  // Span that will contain the description and/or the two-line icon
+  const descriptionSpan = document.createElement('span')
+  descriptionSpan.setAttribute('class', 'pagelib_header_description')
+  if (description) {
+    descriptionSpan.innerHTML = description
+  } else if (descriptionEditable) {
+    const descriptionAnchor = document.createElement('a')
+    const descSvg = makeSvgElement(document, 24, 16,
+      // eslint-disable-next-line max-len
+      '<defs><path id="a" d="M0 0h24v24H0V0z"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path d="M4 9h16v2H4zm0 4h10v2H4z" clip-path="url(#b)"/>')
+    descSvg.setAttribute('viewBox', '4 9 24 8')
+    descriptionAnchor.setAttribute('href', '#')
+    descriptionAnchor.setAttribute('data-action', 'edit_description')
+    descriptionAnchor.innerHTML = descSvg.outerHTML + stringAddDescription
+    descriptionSpan.appendChild(descriptionAnchor)
+  } else {
+    descriptionSpan.innerHTML = ' '
+  }
+  descriptionDiv.appendChild(mainEditPencilAnchor)
+  descriptionDiv.appendChild(descriptionSpan)
+  return descriptionDiv
+}
+
+/**
  * Adds page header with title, pronunciation button, and description.
  * @param {!Document} document
  * @param {!Element} container
@@ -45,51 +101,17 @@ const add = (document, container, displayTitle, descriptionEditable, description
   h1.innerHTML = displayTitle
 
   if (hasPronunciation) {
-    // Create and append the audio "speaker" icon
-    const audioIcon = makeSvgElement(document, 16, 16,
-      // eslint-disable-next-line max-len
-      '<path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path><path d="M0 0h24v24H0z" fill="none"></path>')
-    audioIcon.setAttribute('viewBox', '0 0 24 24')
-    audioIcon.style.margin = '0 6px 2px 6px'
-    const audioAnchor = document.createElement('a')
-    audioAnchor.setAttribute('data-action', 'pronunciation_click')
-    audioAnchor.setAttribute('class', 'pagelib_pronunciation')
-    audioAnchor.setAttribute('style', 'color:inherit;')
-    audioAnchor.innerHTML = audioIcon.outerHTML
-    h1.appendChild(audioAnchor)
+    h1.appendChild(makePronunciationIcon(document))
   }
 
   // Div that will contain the description and edit pencil
-  const descriptionDiv = document.createElement('div')
-  const mainEditPencilAnchor = document.createElement('a')
-  mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
-  mainEditPencilAnchor.setAttribute('class', 'pagelib_edit_section_link')
-
-  // Span that will contain the description and/or the two-line icon
-  const descriptionSpan = document.createElement('span')
-  descriptionSpan.setAttribute('class', 'pagelib_header_description')
-  if (description) {
-    descriptionSpan.innerHTML = description
-  } else if (descriptionEditable) {
-    const descriptionAnchor = document.createElement('a')
-    const descSvg = makeSvgElement(document, 24, 16,
-      // eslint-disable-next-line max-len
-      '<defs><path id="a" d="M0 0h24v24H0V0z"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path d="M4 9h16v2H4zm0 4h10v2H4z" clip-path="url(#b)"/>')
-    descSvg.setAttribute('viewBox', '4 9 24 8')
-    descriptionAnchor.setAttribute('href', '#')
-    descriptionAnchor.setAttribute('data-action', 'edit_description')
-    descriptionAnchor.innerHTML = descSvg.outerHTML + stringAddDescription
-    descriptionSpan.appendChild(descriptionAnchor)
-  } else {
-    descriptionSpan.innerHTML = ' '
-  }
+  const descriptionDiv = makeDescriptionDiv(document, descriptionEditable,
+    description, stringAddDescription)
 
   // Decorative divider that appears below the title and description
   const dividerLine = document.createElement('div')
   dividerLine.setAttribute('class', 'pagelib_divider')
 
-  descriptionDiv.appendChild(mainEditPencilAnchor)
-  descriptionDiv.appendChild(descriptionSpan)
   if (!isMainPage) {
     titleDiv.appendChild(h1)
     titleDiv.appendChild(descriptionDiv)

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -81,14 +81,13 @@ const makeDescriptionDiv = (document, descriptionEditable, description, stringAd
  * @param {boolean} descriptionEditable
  * @param {?string} description
  * @param {!string} stringAddDescription for I18N
- * @param {boolean} hasPronunciation
- * @param {boolean} isMainPage
- * @param {boolean} isRtl
- * @param {boolean} isDarkMode
+ * @param {?boolean} hasPronunciation
+ * @param {?boolean} isMainPage
+ * @param {?boolean} isRtl
  * @return {void}
  */
 const add = (document, container, displayTitle, descriptionEditable, description,
-  stringAddDescription, hasPronunciation, isMainPage, isRtl, isDarkMode) => {
+  stringAddDescription, hasPronunciation, isMainPage, isRtl) => {
 
   const titleDiv = document.createElement('div')
   titleDiv.id = 'heading_0'

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -31,7 +31,7 @@ const makePronunciationIcon = document => {
   audioIcon.style.margin = '0 6px 2px 6px'
   const audioAnchor = document.createElement('a')
   audioAnchor.setAttribute('data-action', 'pronunciation_click')
-  audioAnchor.setAttribute('class', 'pagelib_pronunciation')
+  audioAnchor.setAttribute('class', 'pagelib_header_pronunciation')
   audioAnchor.setAttribute('style', 'color:inherit;')
   audioAnchor.innerHTML = audioIcon.outerHTML
   return audioAnchor

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -40,16 +40,16 @@ const makePronunciationIcon = document => {
 /**
  * Makes a div including whatever is needed to display the description and edit button.
  * @param {!Document} document
- * @param {boolean} descriptionEditable
+ * @param {boolean} isDescriptionEditable
  * @param {?string} description
  * @param {!string} stringAddDescription for I18N
  * @return {!Element}
  */
-const makeDescriptionDiv = (document, descriptionEditable, description, stringAddDescription) => {
+const makeDescriptionDiv = (document, isDescriptionEditable, description, stringAddDescription) => {
   const descriptionDiv = document.createElement('div')
   const editButton = EditTransform.newEditSectionButton(document, 0)
   const mainEditPencilAnchor = EditTransform.queryEditSectionLink(editButton)
-  if (descriptionEditable) {
+  if (isDescriptionEditable) {
     mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
   }
 
@@ -58,7 +58,7 @@ const makeDescriptionDiv = (document, descriptionEditable, description, stringAd
   descriptionSpan.setAttribute('class', 'pagelib_header_description')
   if (description) {
     descriptionSpan.innerHTML = description
-  } else if (descriptionEditable) {
+  } else if (isDescriptionEditable) {
     const descriptionAnchor = document.createElement('a')
     const descSvg = makeSvgElement(document, 24, 16,
       // eslint-disable-next-line max-len

--- a/src/transform/HeaderTransform.js
+++ b/src/transform/HeaderTransform.js
@@ -1,0 +1,120 @@
+const OPACITY_LIGHT = 0.54
+const OPACITY_DARK = 0.7
+
+/**
+ * Makes an SVG element.
+ * @param {!Document} document
+ * @param {!number} width
+ * @param {!number}height
+ * @param {!string} color
+ * @param {!string} svgContents
+ * @return {!Element}
+ */
+const makeSvgElement = (document, width, height, color, svgContents) => {
+  const svg = document.createElement('svg')
+  svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+  svg.setAttribute('width', width)
+  svg.setAttribute('height', height)
+  svg.setAttribute('style', `vertical-align:middle;fill:${color};`)
+  svg.innerHTML = svgContents
+  return svg
+}
+
+/**
+ * Add header with title, pronunciation button, and description.
+ * @param {!Document} document
+ * @param {!Element} container
+ * @param {!string} displayTitle
+ * @param {boolean} descriptionEditable
+ * @param {?string} description
+ * @param {!string} stringAddDescription for I18N
+ * @param {boolean} hasPronunciation
+ * @param {boolean} isMainPage
+ * @param {boolean} isRtl
+ * @param {boolean} isDarkMode
+ * @return {void}
+ */
+const add = (document, container, displayTitle, descriptionEditable, description,
+  stringAddDescription, hasPronunciation, isMainPage, isRtl, isDarkMode) => {
+
+  const titleDiv = document.createElement('div')
+  titleDiv.id = 'heading_0'
+  titleDiv.setAttribute('data-id', 0)
+  titleDiv.className = 'section_heading'
+  titleDiv.setAttribute('dir', isRtl ? 'rtl' : 'ltr')
+
+  // Create the actual H1 heading
+  const h1 = document.createElement('h1')
+  h1.innerHTML = displayTitle
+
+  if (hasPronunciation) {
+    // Create and append the audio "speaker" icon
+    const audioIcon = makeSvgElement(document, 16, 16, 'currentColor',
+      // eslint-disable-next-line max-len
+      '<path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path><path d="M0 0h24v24H0z" fill="none"></path>')
+    audioIcon.setAttribute('viewBox', '0 0 24 24')
+    audioIcon.style.margin = '0 6px 2px 6px'
+    if (isRtl) {
+      audioIcon.style.transform = 'scaleX(-1)'
+    }
+    const audioAnchor = document.createElement('a')
+    audioAnchor.setAttribute('data-action', 'pronunciation_click')
+    audioAnchor.setAttribute('style', 'color:inherit;')
+    audioAnchor.innerHTML = audioIcon.outerHTML
+    h1.appendChild(audioAnchor)
+  }
+
+  // Div that will contain the description and edit pencil
+  const descriptionDiv = document.createElement('div')
+  const mainEditPencilAnchor = document.createElement('a')
+  mainEditPencilAnchor.setAttribute('data-action', 'edit_main')
+  mainEditPencilAnchor.setAttribute('class', 'pagelib_edit_section_link')
+  let style = isDarkMode ? 'filter:invert(100%);-webkit-filter:invert(100%);' : ''
+  style += isRtl ? 'float:left;transform:scaleX(-1);' : 'float:right;'
+  mainEditPencilAnchor.setAttribute('style', style)
+  mainEditPencilAnchor.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
+
+  // Span that will contain the description and/or the two-line icon
+  const descriptionSpan = document.createElement('span')
+  descriptionSpan.setAttribute('style', 'font-size:90%;')
+  if (description) {
+    descriptionSpan.innerHTML = description
+    descriptionSpan.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
+  } else if (descriptionEditable) {
+    const descriptionAnchor = document.createElement('a')
+    const descSvg = makeSvgElement(document, 24, 16, 'currentColor',
+      // eslint-disable-next-line max-len
+      '<defs><path id="a" d="M0 0h24v24H0V0z"/></defs><clipPath id="b"><use xlink:href="#a" overflow="visible"/></clipPath><path d="M4 9h16v2H4zm0 4h10v2H4z" clip-path="url(#b)"/>')
+    descSvg.setAttribute('viewBox', '4 9 24 8')
+    if (isRtl) {
+      descSvg.style.transform = 'scaleX(-1)'
+    }
+    descriptionAnchor.setAttribute('href', '#')
+    descriptionAnchor.setAttribute('data-action', 'edit_description')
+    descriptionAnchor.innerHTML = descSvg.outerHTML + stringAddDescription
+    descriptionAnchor.setAttribute('style', 'font-style:italic;')
+    descriptionSpan.appendChild(descriptionAnchor)
+  } else {
+    descriptionSpan.innerHTML = ' '
+  }
+
+  // Decorative divider that appears below the title and description
+  const dividerLine = document.createElement('div')
+  dividerLine.setAttribute('style',
+    'width:56px;border-top: 1px solid currentColor !important;margin-top:12px;margin-bottom:16px;')
+  dividerLine.style.opacity = isDarkMode ? OPACITY_DARK : OPACITY_LIGHT
+
+  descriptionDiv.appendChild(mainEditPencilAnchor)
+  descriptionDiv.appendChild(descriptionSpan)
+  if (!isMainPage) {
+    titleDiv.appendChild(h1)
+    titleDiv.appendChild(descriptionDiv)
+    titleDiv.appendChild(dividerLine)
+  }
+  container.appendChild(titleDiv)
+}
+
+/** */
+export default {
+  add
+}

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -21,6 +21,7 @@ import FooterLegal from './FooterLegal'
 import FooterMenu from './FooterMenu'
 import FooterReadMore from './FooterReadMore'
 import FooterTransformer from './FooterTransformer'
+import HeaderTransform from './HeaderTransform'
 import LazyLoadTransform from './LazyLoadTransform'
 import LazyLoadTransformer from './LazyLoadTransformer'
 import PlatformTransform from './PlatformTransform'
@@ -45,6 +46,7 @@ export default {
   FooterMenu,
   FooterReadMore,
   FooterTransformer,
+  HeaderTransform,
   LazyLoadTransform,
   LazyLoadTransformer,
   PlatformTransform,


### PR DESCRIPTION
This PR adds a new transform to add a page header, including title, possible description, possible pronunciation button, edit button (for lead section and possibly description as well), and a decorative divider.

One I18N string is passed in assuming I18N is handled on the PCS side.

Also added a new demo for this with the various options.

https://phabricator.wikimedia.org/T201383