### PR TITLE
New edit tranform method for article header

### DIFF
--- a/src/transform/EditTransform.css
+++ b/src/transform/EditTransform.css
@@ -105,3 +105,57 @@ a.pagelib_edit_section_link {
 .pagelib_platform_ios h6.pagelib_edit_section_title + span.pagelib_edit_section_link_container {
     display: none;
 }
+
+/* Wikidata description styling */
+#pagelib_edit_section_title_description {
+    font-size: 14px;
+    line-height: 22px;
+    color: #777D84;
+    margin-top: 3px;
+    margin-bottom: 5px;
+    padding-bottom: 0px;
+}
+
+#pagelib_edit_section_add_title_description {
+    font-size: 14px;
+    font-style: italic;
+    display: inline;
+}
+
+#pagelib_edit_section_add_title_description:before {
+    content: "";
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAMCAYAAAADFL+5AAAAAXNSR0IArs4c6QAAADFJREFUOBFjNE47859hAAHTANoNtnrUAQMdA6P2D3wIMFK7HDg7y4SRFG+NZsMBDwEAJj8Gc0QaQK8AAAAASUVORK5CYII=');
+    background-repeat: no-repeat;
+    width: 1.8em;
+    height: 0.75em;
+    background-size: 1.0em 0.375em;
+    display: inline-block;
+    background-position: left center;
+}
+
+[dir="rtl"] #pagelib_edit_section_add_title_description:before {
+    transform: scaleX(-1);
+}
+
+/* Horizontal divider between title/description and lead section text */
+#pagelib_edit_section_divider {
+    border: 1px solid #ccc;
+    margin-top: 12px;
+    margin-bottom: 16px;
+    width: 60px;
+    margin-left: 0px;
+}
+
+@media (-webkit-min-device-pixel-ratio: 2) {
+    #pagelib_edit_section_divider {
+        border-width: 0.5px;
+    }
+}
+
+[dir="ltr"] #pagelib_edit_section_divider {
+    margin-left: 0px;
+}
+
+[dir="rtl"] #pagelib_edit_section_divider {
+    margin-right: 0px;
+}

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -8,6 +8,12 @@ const CLASS = {
   PROTECTION: { UNPROTECTED: '', PROTECTED: 'page-protected', FORBIDDEN: 'no-editing' }
 }
 
+const IDS = {
+  TITLE_DESCRIPTION: 'pagelib_edit_section_title_description',
+  ADD_TITLE_DESCRIPTION: 'pagelib_edit_section_add_title_description',
+  DIVIDER: 'pagelib_edit_section_divider'
+}
+
 const DATA_ATTRIBUTE = { SECTION_INDEX: 'data-id', ACTION: 'data-action' }
 const ACTION_EDIT_SECTION = 'edit_section'
 
@@ -47,9 +53,10 @@ const newEditSectionButton = (document, index) => {
  * @param {!number} level The *one-based* header or table of contents level.
  * @param {?string} titleHTML Title of this section header.
  * @param {?boolean} showEditPencil Whether to show the "edit" pencil (default is true).
+ * @param {?string} anchor Section anchor used for jumping between sections.
  * @return {!HTMLElement}
  */
-const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil = true) => {
+const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil = true, anchor) => {
   const element = document.createElement('div')
   element.className = CLASS.SECTION_HEADER
 
@@ -64,11 +71,63 @@ const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil 
     element.appendChild(button)
   }
 
+  if (anchor && anchor.length > 0) {
+    // TODO: consider renaming this 'id' to 'anchor' for clarity - would need to update native
+    // code as well - used when TOC sections made to jump to sections.
+    element.id = anchor
+  }
+
   return element
+}
+
+/**
+ * Lead section header is a special case as it needs to show article title and description too,
+ * and in addition to the lead edit pencil, the description can also be editable.
+ * As a client, you may wish to set the ID attribute.
+ * @param {!Document} document
+ * @param {?string} articleDisplayTitle Article display title.
+ * @param {?string} titleDescription Article title description.
+ * @param {?string} addTitleDescriptionString Localized string e.g. 'Add title description'.
+ * @param {?boolean} isTitleDescriptionEditable Whether title description is editable.
+ * @param {?boolean} showEditPencil Whether to show the "edit" pencil (default is true).
+ * @param {?string} anchor Section anchor used for jumping between sections.
+ * @return {!HTMLElement}
+ */
+const newEditLeadSectionHeader = (document, articleDisplayTitle, titleDescription,
+  addTitleDescriptionString, isTitleDescriptionEditable, showEditPencil = true, anchor) => {
+
+  const container = document.createDocumentFragment()
+
+  const header = newEditSectionHeader(document, 0, 1, articleDisplayTitle, showEditPencil, anchor)
+  container.appendChild(header)
+
+  const titleDescriptionExists = titleDescription !== undefined && titleDescription.length > 0
+  if (!isTitleDescriptionEditable || titleDescriptionExists) {
+    const p = document.createElement('p')
+    p.id = IDS.TITLE_DESCRIPTION
+    p.innerHTML = titleDescription
+    container.appendChild(p)
+  } else {
+    const a = document.createElement('a')
+    a.href = '#'
+    a.setAttribute('data-action', 'add_title_description')
+    const p = document.createElement('p')
+    p.id = IDS.ADD_TITLE_DESCRIPTION
+    p.innerHTML = addTitleDescriptionString
+    a.appendChild(p)
+    container.appendChild(a)
+  }
+
+  const divider = document.createElement('hr')
+  divider.id = IDS.DIVIDER
+  container.appendChild(divider)
+
+  return container
 }
 
 export default {
   CLASS,
   newEditSectionButton,
-  newEditSectionHeader
+  newEditSectionHeader,
+  newEditLeadSectionHeader
 }


### PR DESCRIPTION
Article header turned out to be simpler to implement as a special case of a section header, which the edit transform already supported.