### PR TITLE
Fix for dark / black theme bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     },
     {
       "path": "build/wikimedia-page-library-transform.css",
-      "maxSize": "27.1KB"
+      "maxSize": "27.5KB"
     },
     {
       "path": "build/wikimedia-page-library-transform.js",

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -36,9 +36,7 @@ styles with only the things which need tweaking.
 
 /* baseline .content */
 /* Fixes T214728 */
-.pagelib_theme_dark .content,
-.pagelib_theme_sepia .content,
-.pagelib_theme_black .content {
+.content {
   background-color: unset !important;
 }
 

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -34,6 +34,14 @@ styles with only the things which need tweaking.
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAGJJREFUKFN1jdENgCAMBYmJn47Bak7DZrhTpc/XIm34OAjXA4qIgHI/dSBbLGTcOKjBryFlinGmjDQGiOF0MQkxI3v5wq6L38qR7SnsAx8ul37igPjAd+o5Oz2MRA+xY4ZSXuaW6wYouOLpAAAAAElFTkSuQmCC);
 }
 
+/* baseline .content */
+/* Fixes T214728 */
+.pagelib_theme_dark .content,
+.pagelib_theme_sepia .content,
+.pagelib_theme_black .content {
+  background-color: unset !important;
+}
+
 /* baseline table */
 .pagelib_theme_dark .content table,
 .pagelib_theme_dark .content td:not(.pagelib_theme_div_do_not_apply_baseline),


### PR DESCRIPTION
https://phabricator.wikimedia.org/T214728

Fixes bug from ticket above.

- works with either `skins.minerva.base.reset` or `skins.minerva.base.styles`
- plays nice with edit pencil transform (my first attempt used `transparent` instead of `unset` and did not play nice)