### PR TITLE
Pre-emptively override upstream CSS changes

### DIFF
--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -82,6 +82,7 @@
 table.infobox caption {
   text-align: center;
   font-weight: bold;
+  padding: 16px 16px 8px 16px;
 }
 
 div.pagelib_collapse_table_container {

--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -82,7 +82,7 @@
 table.infobox caption {
   text-align: center;
   font-weight: bold;
-  padding: 16px 16px 8px 16px;
+  padding: 10px 10px 0px 10px;
 }
 
 div.pagelib_collapse_table_container {

--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -74,6 +74,11 @@
   border-style: none !important;
 }
 
+.content ol {
+  list-style: decimal inside;
+  padding: 0;
+}
+
 table.infobox caption {
   text-align: center;
   font-weight: bold;

--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -74,11 +74,6 @@
   border-style: none !important;
 }
 
-.content ol {
-  list-style: decimal inside;
-  padding: 0;
-}
-
 table.infobox caption {
   text-align: center;
   font-weight: bold;

--- a/src/transform/OrderedList.css
+++ b/src/transform/OrderedList.css
@@ -1,0 +1,8 @@
+/*
+Fix for upstream change: https://gerrit.wikimedia.org/r/#/c/mediawiki/skins/MinervaNeue/+/494374/3/resources/skins.minerva.content.styles/lists.less
+Which caused this clipping: https://phabricator.wikimedia.org/T150377#5019102
+*/
+.content ol {
+  list-style: decimal inside;
+  padding: 0;
+}

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -29,6 +29,7 @@ import RedLinks from './RedLinks'
 import ReferenceCollection from './ReferenceCollection'
 import Throttle from './Throttle'
 import WidenImage from './WidenImage'
+import './OrderedList.css'
 
 export default {
   // todo: rename CollapseTableTransform.


### PR DESCRIPTION
There are changes coming to the upstream CSS that will break the display of reference lists in the apps. It might also break other ordered lists, but haven't found another repro case. This change preemptively overrides that style to ensure it remains unchanged in the apps for now. Context:

https://phabricator.wikimedia.org/T150377#5019102

Screenshots with CSS manually updated to the upstream proposed change:

![Screenshot_20190313-122011](https://user-images.githubusercontent.com/741327/54296070-99d22400-458a-11e9-8b03-cb58e7eb75c2.png)

![Simulator Screen Shot - iPhone X - 2019-03-12 at 16 14 00](https://user-images.githubusercontent.com/741327/54296083-a0609b80-458a-11e9-99b2-13165a0f15a5.png)

There are also changes to padding around captions pending, I've added an override for those as well based on this thread: 
https://phabricator.wikimedia.org/T168861#5019022
