### PR TITLE
Allow client to set margin/padding on body element

### DIFF
--- a/src/transform/BodySpacingTransform.ts
+++ b/src/transform/BodySpacingTransform.ts
@@ -7,25 +7,25 @@ interface Spacing {
 
 /**
  * Sets the margins on an element via inline styles.
- * @param {!HTMLElement} element the element that needs the margins adjusted.
+ * @param {!HTMLBodyElement} bodyElement the element that needs the margins adjusted.
  *   For the apps this is usually the body element.
  * @param {Spacing} values { top, right, bottom, left }
  *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
  * @param callback callback function
  * @return {void}
  */
-const setMargins = (element: HTMLElement, values: Spacing, callback?: () => void): void => {
+const setMargins = (bodyElement: HTMLBodyElement, values: Spacing, callback?: () => void): void => {
   if (values.top !== undefined) {
-    element.style.marginTop = values.top
+    bodyElement.style.marginTop = values.top
   }
   if (values.right !== undefined) {
-    element.style.marginRight = values.right
+    bodyElement.style.marginRight = values.right
   }
   if (values.bottom !== undefined) {
-    element.style.marginBottom = values.bottom
+    bodyElement.style.marginBottom = values.bottom
   }
   if (values.left !== undefined) {
-    element.style.marginLeft = values.left
+    bodyElement.style.marginLeft = values.left
   }
   if (callback) {
     callback()
@@ -34,25 +34,25 @@ const setMargins = (element: HTMLElement, values: Spacing, callback?: () => void
 
 /**
  * Sets padding on an element via inline styles.
- * @param {!HTMLElement} element the element that needs the padding adjusted.
+ * @param {!HTMLBodyElement} bodyElement the element that needs the padding adjusted.
  *   For the apps this is usually the body element.
  * @param {Spacing} values { top, right, bottom, left }
  *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
  * @param callback callback function
  * @return {void}
  */
-const setPadding = (element: HTMLElement, values: Spacing, callback?: () => void): void => {
+const setPadding = (bodyElement: HTMLBodyElement, values: Spacing, callback?: () => void): void => {
   if (values.top !== undefined) {
-    element.style.paddingTop = values.top
+    bodyElement.style.paddingTop = values.top
   }
   if (values.right !== undefined) {
-    element.style.paddingRight = values.right
+    bodyElement.style.paddingRight = values.right
   }
   if (values.bottom !== undefined) {
-    element.style.paddingBottom = values.bottom
+    bodyElement.style.paddingBottom = values.bottom
   }
   if (values.left !== undefined) {
-    element.style.paddingLeft = values.left
+    bodyElement.style.paddingLeft = values.left
   }
   if (callback) {
     callback()

--- a/src/transform/BodySpacingTransform.ts
+++ b/src/transform/BodySpacingTransform.ts
@@ -6,26 +6,26 @@ interface Spacing {
 }
 
 /**
- * Sets the margins on the body element via inline styles.
- * @param {!Document} document
+ * Sets the margins on an element via inline styles.
+ * @param {!HTMLElement} element the element that needs the margins adjusted.
+ *   For the apps this is usually the body element.
  * @param {Spacing} values { top, right, bottom, left }
  *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
  * @param callback callback function
  * @return {void}
  */
-const setMargins = (document: Document, values: Spacing, callback?: () => void): void => {
-  const body: HTMLElement = document.body
+const setMargins = (element: HTMLElement, values: Spacing, callback?: () => void): void => {
   if (values.top !== undefined) {
-    body.style.marginTop = values.top
+    element.style.marginTop = values.top
   }
   if (values.right !== undefined) {
-    body.style.marginRight = values.right
+    element.style.marginRight = values.right
   }
   if (values.bottom !== undefined) {
-    body.style.marginBottom = values.bottom
+    element.style.marginBottom = values.bottom
   }
   if (values.left !== undefined) {
-    body.style.marginLeft = values.left
+    element.style.marginLeft = values.left
   }
   if (callback) {
     callback()
@@ -33,26 +33,26 @@ const setMargins = (document: Document, values: Spacing, callback?: () => void):
 }
 
 /**
- * Sets padding on the body element via inline styles.
- * @param {!Document} document
+ * Sets padding on an element via inline styles.
+ * @param {!HTMLElement} element the element that needs the padding adjusted.
+ *   For the apps this is usually the body element.
  * @param {Spacing} values { top, right, bottom, left }
  *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
  * @param callback callback function
  * @return {void}
  */
-const setPadding = (document: Document, values: Spacing, callback?: () => void): void => {
-  const body: HTMLElement = document.body
+const setPadding = (element: HTMLElement, values: Spacing, callback?: () => void): void => {
   if (values.top !== undefined) {
-    body.style.paddingTop = values.top
+    element.style.paddingTop = values.top
   }
   if (values.right !== undefined) {
-    body.style.paddingRight = values.right
+    element.style.paddingRight = values.right
   }
   if (values.bottom !== undefined) {
-    body.style.paddingBottom = values.bottom
+    element.style.paddingBottom = values.bottom
   }
   if (values.left !== undefined) {
-    body.style.paddingLeft = values.left
+    element.style.paddingLeft = values.left
   }
   if (callback) {
     callback()

--- a/src/transform/BodySpacingTransform.ts
+++ b/src/transform/BodySpacingTransform.ts
@@ -1,0 +1,65 @@
+interface Spacing {
+  top?: string
+  right?: string
+  bottom?: string
+  left?: string
+}
+
+/**
+ * Sets the margins on the body element via inline styles.
+ * @param {!Document} document
+ * @param {Spacing} values { top, right, bottom, left }
+ *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
+ * @param callback callback function
+ * @return {void}
+ */
+const setMargins = (document: Document, values: Spacing, callback?: () => void): void => {
+  const body: HTMLElement = document.body
+  if (values.top !== undefined) {
+    body.style.marginTop = values.top
+  }
+  if (values.right !== undefined) {
+    body.style.marginRight = values.right
+  }
+  if (values.bottom !== undefined) {
+    body.style.marginBottom = values.bottom
+  }
+  if (values.left !== undefined) {
+    body.style.marginLeft = values.left
+  }
+  if (callback) {
+    callback()
+  }
+}
+
+/**
+ * Sets padding on the body element via inline styles.
+ * @param {!Document} document
+ * @param {Spacing} values { top, right, bottom, left }
+ *   Use value strings with units, e.g. '16px'. Undefined values are ignored.
+ * @param callback callback function
+ * @return {void}
+ */
+const setPadding = (document: Document, values: Spacing, callback?: () => void): void => {
+  const body: HTMLElement = document.body
+  if (values.top !== undefined) {
+    body.style.paddingTop = values.top
+  }
+  if (values.right !== undefined) {
+    body.style.paddingRight = values.right
+  }
+  if (values.bottom !== undefined) {
+    body.style.paddingBottom = values.bottom
+  }
+  if (values.left !== undefined) {
+    body.style.paddingLeft = values.left
+  }
+  if (callback) {
+    callback()
+  }
+}
+
+export default {
+  setMargins,
+  setPadding
+}

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -8,6 +8,7 @@
 // used by the theme transform for whatever it is you are trying to override.
 import ThemeTransform from './ThemeTransform'
 
+import BodySpacingTransform from './BodySpacingTransform'
 import CollapseTable from './CollapseTable'
 import CollectionUtilities from './CollectionUtilities'
 import CompatibilityTransform from './CompatibilityTransform'
@@ -32,6 +33,7 @@ import WidenImage from './WidenImage'
 import './OrderedList.css'
 
 export default {
+  BodySpacingTransform,
   // todo: rename CollapseTableTransform.
   CollapseTable,
   CollectionUtilities,

--- a/test/transform/BodySpacingTransform.test.js
+++ b/test/transform/BodySpacingTransform.test.js
@@ -13,18 +13,21 @@ describe('BodySpacingTransform', () => {
     it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setMargins(document, { right: '8px', left: '16px' })
-      const style = 'margin-right: 8px; margin-left: 16px;'
-      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+      assert.strictEqual(document.body.style.marginRight,'8px')
+      assert.strictEqual(document.body.style.marginLeft,'16px')
     })
 
     it('all', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setMargins(document,
         { top: '1px', right: '2px', bottom: '3px', left: '4px' })
-      const style = 'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;'
-      assert.strictEqual(document.body.outerHTML, `<body style="${style}"><p></p></body>`)
+      assert.strictEqual(document.body.style.marginTop,'1px')
+      assert.strictEqual(document.body.style.marginRight,'2px')
+      assert.strictEqual(document.body.style.marginBottom,'3px')
+      assert.strictEqual(document.body.style.marginLeft,'4px')
     })
   })
+
   describe('.setPadding()', () => {
     it('no values', () => {
       const document = domino.createDocument('<p></p>')
@@ -35,16 +38,18 @@ describe('BodySpacingTransform', () => {
     it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setPadding(document, { right: '8px', left: '16px' })
-      const style = 'padding-right: 8px; padding-left: 16px;'
-      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+      assert.strictEqual(document.body.style.paddingRight,'8px')
+      assert.strictEqual(document.body.style.paddingLeft,'16px')
     })
 
     it('all', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setPadding(document,
         { top: '1px', right: '2px', bottom: '3px', left: '4px' })
-      const style = 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;'
-      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+      assert.strictEqual(document.body.style.paddingTop,'1px')
+      assert.strictEqual(document.body.style.paddingRight,'2px')
+      assert.strictEqual(document.body.style.paddingBottom,'3px')
+      assert.strictEqual(document.body.style.paddingLeft,'4px')
     })
   })
 })

--- a/test/transform/BodySpacingTransform.test.js
+++ b/test/transform/BodySpacingTransform.test.js
@@ -10,7 +10,7 @@ describe('BodySpacingTransform', () => {
       assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
     })
 
-    it('just width', () => {
+    it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setMargins(document, { right: '8px', left: '16px' })
       const style = 'margin-right: 8px; margin-left: 16px;'
@@ -32,7 +32,7 @@ describe('BodySpacingTransform', () => {
       assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
     })
 
-    it('just width', () => {
+    it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
       BodySpacingTransform.setPadding(document, { right: '8px', left: '16px' })
       const style = 'padding-right: 8px; padding-left: 16px;'

--- a/test/transform/BodySpacingTransform.test.js
+++ b/test/transform/BodySpacingTransform.test.js
@@ -1,0 +1,50 @@
+import { BodySpacingTransform } from '../../build/wikimedia-page-library-transform'
+import assert from 'assert'
+import domino from 'domino'
+
+describe('BodySpacingTransform', () => {
+  describe('.setMargins()', () => {
+    it('no values', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setMargins(document, {})
+      assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
+    })
+
+    it('just width', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setMargins(document, { right: '8px', left: '16px' })
+      const style = 'margin-right: 8px; margin-left: 16px;'
+      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+    })
+
+    it('all', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setMargins(document,
+        { top: '1px', right: '2px', bottom: '3px', left: '4px' })
+      const style = 'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;'
+      assert.strictEqual(document.body.outerHTML, `<body style="${style}"><p></p></body>`)
+    })
+  })
+  describe('.setPadding()', () => {
+    it('no values', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setPadding(document, {})
+      assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
+    })
+
+    it('just width', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setPadding(document, { right: '8px', left: '16px' })
+      const style = 'padding-right: 8px; padding-left: 16px;'
+      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+    })
+
+    it('all', () => {
+      const document = domino.createDocument('<p></p>')
+      BodySpacingTransform.setPadding(document,
+        { top: '1px', right: '2px', bottom: '3px', left: '4px' })
+      const style = 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;'
+      assert.strictEqual(document.body.outerHTML,`<body style="${style}"><p></p></body>`)
+    })
+  })
+})

--- a/test/transform/BodySpacingTransform.test.js
+++ b/test/transform/BodySpacingTransform.test.js
@@ -6,20 +6,20 @@ describe('BodySpacingTransform', () => {
   describe('.setMargins()', () => {
     it('no values', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setMargins(document, {})
+      BodySpacingTransform.setMargins(document.body, {})
       assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
     })
 
     it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setMargins(document, { right: '8px', left: '16px' })
+      BodySpacingTransform.setMargins(document.body, { right: '8px', left: '16px' })
       assert.strictEqual(document.body.style.marginRight,'8px')
       assert.strictEqual(document.body.style.marginLeft,'16px')
     })
 
     it('all', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setMargins(document,
+      BodySpacingTransform.setMargins(document.body,
         { top: '1px', right: '2px', bottom: '3px', left: '4px' })
       assert.strictEqual(document.body.style.marginTop,'1px')
       assert.strictEqual(document.body.style.marginRight,'2px')
@@ -31,20 +31,20 @@ describe('BodySpacingTransform', () => {
   describe('.setPadding()', () => {
     it('no values', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setPadding(document, {})
+      BodySpacingTransform.setPadding(document.body, {})
       assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
     })
 
     it('just left + right', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setPadding(document, { right: '8px', left: '16px' })
+      BodySpacingTransform.setPadding(document.body, { right: '8px', left: '16px' })
       assert.strictEqual(document.body.style.paddingRight,'8px')
       assert.strictEqual(document.body.style.paddingLeft,'16px')
     })
 
     it('all', () => {
       const document = domino.createDocument('<p></p>')
-      BodySpacingTransform.setPadding(document,
+      BodySpacingTransform.setPadding(document.body,
         { top: '1px', right: '2px', bottom: '3px', left: '4px' })
       assert.strictEqual(document.body.style.paddingTop,'1px')
       assert.strictEqual(document.body.style.paddingRight,'2px')


### PR DESCRIPTION
This commit introduces a new transform, called BodySpacingTransform.
It allows client to set margins and padding on the body element of the
given HTML Document.

Bug: https://phabricator.wikimedia.org/T201382