### PR TITLE
Remove background-color rule

### DIFF
--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -34,12 +34,6 @@ styles with only the things which need tweaking.
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAadEVYdFNvZnR3YXJlAFBhaW50Lk5FVCB2My41LjEwMPRyoQAAAGJJREFUKFN1jdENgCAMBYmJn47Bak7DZrhTpc/XIm34OAjXA4qIgHI/dSBbLGTcOKjBryFlinGmjDQGiOF0MQkxI3v5wq6L38qR7SnsAx8ul37igPjAd+o5Oz2MRA+xY4ZSXuaW6wYouOLpAAAAAElFTkSuQmCC);
 }
 
-/* baseline .content */
-/* Fixes T214728 */
-.content {
-  background-color: initial !important;
-}
-
 /* baseline table */
 .pagelib_theme_dark .content table,
 .pagelib_theme_dark .content td:not(.pagelib_theme_div_do_not_apply_baseline),


### PR DESCRIPTION
Undoes the fix for T214728. The negative side effect for this is that
it caused issues with mobile-html.

I don't believe this rule is still needed now that the PCS base CSS
removes most of the unneeded CSS rules from Minerva.

Bug: https://phabricator.wikimedia.org/T217837