### PR TITLE
add `build:debug` option which correctly builds sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html",
     "lint:all": "npm run -s lint .",
     "build": "NODE_ENV=production webpack -p",
+    "build:debug": "NODE_ENV=development webpack --debug --output-pathinfo --mode=development",
     "build:watch": "webpack -dw --devtool source-map",
     "serve:watch": "webpack-dev-server -dw",
     "test:size": "bundlesize",


### PR DESCRIPTION
Add `build:debug` script option which tells web pack to use `development` mode. Prevents minification and creates correct source map files.

Info: https://stackoverflow.com/a/46372748