### PR TITLE
Unset any explicit height of collapsible tables

### DIFF
--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -180,7 +180,7 @@ div.pagelib_collapse_table_container {
 .pagelib_collapse_table_container table {
     display: block;
     width: 100% !important;
-    height: unset !important;
+    height: initial !important;
 }
 
 /* Fix for upstream CSS landscape tablet layout interfering with collapsible table width. */

--- a/src/transform/CollapseTable.css
+++ b/src/transform/CollapseTable.css
@@ -179,7 +179,8 @@ div.pagelib_collapse_table_container {
    but only for tables we collapse. */
 .pagelib_collapse_table_container table {
     display: block;
-    width: 100% !important
+    width: 100% !important;
+    height: unset !important;
 }
 
 /* Fix for upstream CSS landscape tablet layout interfering with collapsible table width. */


### PR DESCRIPTION
When adding `display: block` any height mistakenly set in the table CSS is applied, causing the table to be truncated.

https://phabricator.wikimedia.org/T223477