### PR TITLE
page library: allow clients to adjust text size

### DIFF
--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -1,3 +1,4 @@
+import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
@@ -55,6 +56,12 @@ const setMulti = (document, settings, onSuccess) => {
   }
   if (settings.scrollTop !== undefined) {
     Scroller.setScrollTop(settings.scrollTop)
+  }
+  if (settings.setTextSizeAdjustmentPercentage !== undefined) {
+    AdjustTextSize.setTextSizeAdjustmentPercentage(
+      document.body,
+      settings.setTextSizeAdjustmentPercentage
+    )
   }
 
   if (onSuccess instanceof Function) {
@@ -123,6 +130,21 @@ const setScrollTop = (document, scrollTop, onSuccess) => {
 }
 
 /**
+ * Sets text size adjustment percentage of the body element
+ * @param  {!Document} document
+ * @param  {!string} textSize percentage for text-size-adjust in format of string, like '100%'
+ * @param  {?OnSuccess} onSuccess onSuccess callback
+ * @return {void}
+ */
+const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
+  AdjustTextSize.setPercentage(document.body, textSize)
+
+  if (onSuccess instanceof Function) {
+    onSuccess()
+  }
+}
+
+/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -138,6 +160,7 @@ export default {
   setDimImages,
   setMargins,
   setScrollTop,
+  setTextSizeAdjustmentPercentage,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -34,7 +34,8 @@ const onPageLoad = (window, document) => {
  * during initial page load.
  * @param {!Document} document
  * @param {!{}} settings client settings
- *   { platform, clientVersion, theme, dimImages, margins, areTablesCollapsed, scrollTop }
+ *   { platform, clientVersion, theme, dimImages, margins, areTablesCollapsed, scrollTop,
+ *   textSizeAdjustmentPercentage }
  * @param {?PageMods~Function} onSuccess callback
  * @return {void}
  */
@@ -57,10 +58,10 @@ const setMulti = (document, settings, onSuccess) => {
   if (settings.scrollTop !== undefined) {
     Scroller.setScrollTop(settings.scrollTop)
   }
-  if (settings.setTextSizeAdjustmentPercentage !== undefined) {
-    AdjustTextSize.setTextSizeAdjustmentPercentage(
+  if (settings.textSizeAdjustmentPercentage !== undefined) {
+    AdjustTextSize.setPercentage(
       document.body,
-      settings.setTextSizeAdjustmentPercentage
+      settings.textSizeAdjustmentPercentage
     )
   }
 

--- a/src/transform/AdjustTextSize.ts
+++ b/src/transform/AdjustTextSize.ts
@@ -1,6 +1,7 @@
 /**
- * Set text size adjustment percentage of the body element
+ * Sets text size adjustment percentage of the body element
  * @param  {!HTMLBodyElement} body that needs the margins adjusted.
+ * @param  {!string} textSize percentage for text-size-adjust in format of string, like '100%'
  * @return {void}
  */
 const setPercentage = (body: HTMLBodyElement, textSize: string): void => {

--- a/src/transform/AdjustTextSize.ts
+++ b/src/transform/AdjustTextSize.ts
@@ -1,0 +1,18 @@
+/**
+ * Set text size adjustment percentage of the body element
+ * @param  {!HTMLBodyElement} body that needs the margins adjusted.
+ * @return {void}
+ */
+const setPercentage = (body: HTMLBodyElement, textSize: string): void => {
+    if (textSize){
+        // casting body style to avoid errors with the subscript operator and typescript
+        // see https://stackoverflow.com/questions/37655393
+        (<any>body.style)['-webkit-text-size-adjust'] = textSize;
+        (<any>body.style)['text-size-adjust'] = textSize;
+    }
+}
+
+
+export default {
+    setPercentage
+}

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -8,6 +8,7 @@
 // used by the theme transform for whatever it is you are trying to override.
 import ThemeTransform from './ThemeTransform'
 
+import AdjustTextSize from './AdjustTextSize'
 import BodySpacingTransform from './BodySpacingTransform'
 import CollapseTable from './CollapseTable'
 import CollectionUtilities from './CollectionUtilities'
@@ -33,6 +34,7 @@ import WidenImage from './WidenImage'
 import './OrderedList.css'
 
 export default {
+  AdjustTextSize,
   BodySpacingTransform,
   // todo: rename CollapseTableTransform.
   CollapseTable,

--- a/test/transform/AdjustTextSizeTransform.test.js
+++ b/test/transform/AdjustTextSizeTransform.test.js
@@ -1,0 +1,20 @@
+import { AdjustTextSize } from '../../build/wikimedia-page-library-transform'
+import assert from 'assert'
+import domino from 'domino'
+
+describe('AdjustTextSize', () => {
+  describe('.setPercentage()', () => {
+    it('no values', () => {
+      const document = domino.createDocument('<p></p>')
+      AdjustTextSize.setPercentage(document.body)
+      assert.strictEqual(document.body.outerHTML, '<body><p></p></body>')
+    })
+
+    it('set string value', () => {
+      const document = domino.createDocument('<p></p>')
+      AdjustTextSize.setPercentage(document.body, '80%')
+      assert.strictEqual(document.body.style['-webkit-text-size-adjust'],'80%')
+      assert.strictEqual(document.body.style['text-size-adjust'],'80%')
+    })
+  })
+})

--- a/test/transform/AdjustTextSizeTransform.test.js
+++ b/test/transform/AdjustTextSizeTransform.test.js
@@ -13,8 +13,8 @@ describe('AdjustTextSize', () => {
     it('set string value', () => {
       const document = domino.createDocument('<p></p>')
       AdjustTextSize.setPercentage(document.body, '80%')
-      assert.strictEqual(document.body.style['-webkit-text-size-adjust'],'80%')
-      assert.strictEqual(document.body.style['text-size-adjust'],'80%')
+      assert.strictEqual(document.body.style['-webkit-text-size-adjust'], '80%')
+      assert.strictEqual(document.body.style['text-size-adjust'], '80%')
     })
   })
 })


### PR DESCRIPTION
When native clients load articles via mobile-html, they need to be able
to adjust the font size.

PS: AllTransforms demo coming in a separate patch with some refactoring.
Bug: T222752