### PR TITLE
TemplateStyles CSS appearing in quick facts header

### DIFF
--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -108,8 +108,9 @@ const extractEligibleHeaderText = (document, header, pageTitle) => {
   fragment.appendChild(header.cloneNode(true))
   const fragmentHeader = fragment.querySelector('th')
 
-  Polyfill.querySelectorAll(fragmentHeader, '.geo, .coordinates, sup.reference, ol, ul')
-    .forEach(el => el.remove())
+  Polyfill.querySelectorAll(
+    fragmentHeader, '.geo, .coordinates, sup.reference, ol, ul, style, script'
+  ).forEach(el => el.remove())
 
   const childNodesArray = Array.prototype.slice.call(fragmentHeader.childNodes)
   if (pageTitle) {

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -198,6 +198,34 @@ describe('CollapseTable', () => {
       const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
       assert.equal(text, 'goat')
     })
+    it('extracted text excludes style', () => {
+      // 'enwiki > Brussels-Chapel railway station'
+      const doc = domino.createDocument(`
+        <table><tr>
+          <th>
+            <style>ul {text-align:center}</style>
+            <i>goat</i>
+          </th>
+        </tr></table>
+      `)
+      const header = doc.querySelector('th')
+      const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
+      assert.equal(text, 'goat')
+    })
+    it('extracted text excludes script', () => {
+      // 'enwiki > Brussels-Chapel railway station'
+      const doc = domino.createDocument(`
+        <table><tr>
+          <th>
+            <script>function(){var x = 1;}</script>
+            <i>goat</i>
+          </th>
+        </tr></table>
+      `)
+      const header = doc.querySelector('th')
+      const text = extractEligibleHeaderText(doc, header, 'SampleTitle')
+      assert.equal(text, 'goat')
+    })
     it('extracted text skips element if page title starts with element textContent', () => {
       // 'dewiki > Hornburg (Mansfelder Land)'
       // 'enwiki > Ramon Magsaysay High School, Manila'


### PR DESCRIPTION
Per https://phabricator.wikimedia.org/T215059#4933826, is not possible to use innerText, this patch is stripping style and script from fragmentHeader instead.

Bug: [T215059](https://phabricator.wikimedia.org/T215059)