### PR TITLE
BREAKING: Add Footer implementation

### DIFF
--- a/demo/FooterTransformer.html
+++ b/demo/FooterTransformer.html
@@ -71,7 +71,6 @@
         configuration.readMore.header, configuration.readMore.limit, configuration.license.template,
         configuration.license.substitution, configuration.license.substitutionClickCallback,
         configuration.readMore.loadCallback, configuration.readMore.saveClickHandler)
-      pagelib.FooterContainer.updateLeftAndRightMargin(16, window.document)
     </script>
   </body>
 

--- a/demo/lib/TransformationControls/addFooterControl.js
+++ b/demo/lib/TransformationControls/addFooterControl.js
@@ -6,7 +6,6 @@ const { expandIframeHeight } = util
 const addFooterContainer = (iframeWindow, iframeDocument) => {
   const containerFragment = iframeWindow.pagelib.FooterContainer.containerFragment(iframeDocument)
   iframeDocument.body.appendChild(containerFragment)
-  iframeWindow.pagelib.FooterContainer.updateLeftAndRightMargin(16, iframeDocument)
 }
 
 const addFooterMenu = (iframeWindow, iframeDocument) => {

--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -149,12 +149,12 @@ pagelib.c1.PageMods.addFooter(
 `'http://localhost:7231/en.wikipedia.org/v1'` is for a local RESTBase instance.
 Production uses something like `'https://en.wikipedia.org/api/rest_v1'`.
 
-#### updateSaveButtonForTitle()
+#### updateReadMoreSaveButtonForTitle()
 The client is expected to call this function for every "Read more" title received.
 
 Example:
 ```
-pagelib.c1.PageMods.updateSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
+pagelib.c1.PageMods.updateReadMoreSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
 ```
 
 

--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -123,7 +123,7 @@ Adds a footer to the page showing metadata of the page, like how many other lang
 
 Example:
 ```
-pagelib.c1.PageMods.addFooter(
+pagelib.c1.Footer.add(
     document,
     'Knight Lore',  // articleTitle
     [pagelib.c1.Footer.MenuItemType.languages, pagelib.c1.Footer.MenuItemType.lastEdited, pagelib.c1.Footer.MenuItemType.pageIssues, pagelib.c1.Footer.MenuItemType.disambiguation, pagelib.c1.Footer.MenuItemType.talkPage],  // menuItems
@@ -154,7 +154,7 @@ The client is expected to call this function for every "Read more" title receive
 
 Example:
 ```
-pagelib.c1.PageMods.updateReadMoreSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
+pagelib.c1.Footer.updateReadMoreSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
 ```
 
 

--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -73,7 +73,7 @@ pagelib.c1.PageMods.setMulti(document, {
 )
 ```
 
-### setTheme()
+#### setTheme()
 Sets the theme. See possible values listed in `setMulti()`.
 
 Example:
@@ -81,7 +81,7 @@ Example:
 pagelib.c1.PageMods.setTheme(document, pagelib.c1.Themes.SEPIA)
 ```
 
-### setDimImages()
+#### setDimImages()
 Turns on or off dimming of images.
 
 Example:
@@ -89,7 +89,7 @@ Example:
 pagelib.c1.PageMods.setDimImages(document, true)
 ```
 
-### setMargins()
+#### setMargins()
 Sets the margins on the `<body>` tag.
 
 Example:
@@ -97,7 +97,7 @@ Example:
 pagelib.c1.PageMods.setMargins(document, { top: '128px', right: '32px', bottom: '16px', left: '32px' })
 ```
 
-### setScrollTop()
+#### setScrollTop()
 Sets the top-most vertical position to scroll to in pixel. Use this to adjust for any decor overlaying the top of the viewport. Default: 0
 
 Example:
@@ -105,15 +105,56 @@ Example:
 pagelib.c1.PageMods.setScrollTop(document, 64)
 ```
 
-## Sections
+### Sections
 A set of utilities to handle Sections properties.
 
-### getOffsets()
+#### getOffsets()
 Gets Section Offsets object to handle quick scrolling in the table of contents.
 
 Example:
 ```
 pagelib.c1.Sections.getOffsets(document)
+```
+
+### Footer
+
+#### add()
+Adds a footer to the page showing metadata of the page, like how many other languages it's available in, when it was last edited, links to history, talk pages, read more, view in browser, license text. 
+
+Example:
+```
+pagelib.c1.PageMods.addFooter(
+    document,
+    'Knight Lore',  // articleTitle
+    [pagelib.c1.Footer.MenuItemType.languages, pagelib.c1.Footer.MenuItemType.lastEdited, pagelib.c1.Footer.MenuItemType.pageIssues, pagelib.c1.Footer.MenuItemType.disambiguation, pagelib.c1.Footer.MenuItemType.talkPage],  // menuItems
+    { 
+        'readMoreHeading': 'Read more',
+        'menuDisambiguationTitle': 'Similar pages',
+        'menuLanguagesTitle': 'Available in 9 other languages',
+        'menuHeading': 'About this article',
+        'menuLastEditedSubtitle': 'Full edit history',
+        'menuLastEditedTitle': 'Edited today',
+        'licenseString': 'Content is available under $1 unless otherwise noted.',
+        'menuTalkPageTitle': 'View talk page',
+        'menuPageIssuesTitle': 'Page issues',
+        'viewInBrowserString': 'View article in browser',
+        'licenseSubstitutionString': 'CC BY-SA 3.0',
+        'menuCoordinateTitle': 'View on a map'
+     }, // localizedStrings
+     3,  // readMoreItemCount
+     'http://localhost:7231/en.wikipedia.org/v1' // baseUrl for getting ReadMore items
+)
+```
+
+`'http://localhost:7231/en.wikipedia.org/v1'` is for a local RESTBase instance.
+Production uses something like `'https://en.wikipedia.org/api/rest_v1'`.
+
+#### updateSaveButtonForTitle()
+The client is expected to call this function for every "Read more" title received.
+
+Example:
+```
+pagelib.c1.PageMods.updateSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "npm-run-all": "4.1.5",
     "postcss-loader": "3.0.0",
     "pre-commit": "1.2.2",
+    "request": "2.88.0",
     "style-loader": "0.23.1",
     "ts-loader": "5.3.1",
     "ts-node": "7.0.1",

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -1,5 +1,150 @@
+import FooterContainer from '../../transform/FooterContainer'
+import FooterLegal from '../../transform/FooterLegal'
 import FooterMenu from '../../transform/FooterMenu'
+import FooterReadMore from '../../transform/FooterReadMore'
+
+/**
+ * Adds footer to the end of the document
+ * @param  {!Document} document
+ * @param  {!list} articleTitle article title for related pages
+ * @param  {!string} menuItems menu items to add
+ * @param  {!map} localizedStrings localized strings
+ * @param  {!number} readMoreItemCount number of read more items to add
+ * @param  {!string} readMoreBaseURL base url for restbase to fetch read more
+ * @return {void}
+ */
+const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCount,
+  readMoreBaseURL) => {
+  // Add container
+  if (FooterContainer.isContainerAttached(document) === false) {
+    document.body.appendChild(FooterContainer.containerFragment(document))
+  }
+  // Add menu
+  FooterMenu.setHeading(
+    localizedStrings.menuHeading,
+    'pagelib_footer_container_menu_heading',
+    document
+  )
+  menuItems.forEach(item => {
+    let title = ''
+    let subtitle = ''
+    let menuItemTypeString = ''
+    switch (item) {
+    case FooterMenu.MenuItemType.languages:
+      menuItemTypeString = 'languages'
+      title = localizedStrings.menuLanguagesTitle
+      break
+    case FooterMenu.MenuItemType.lastEdited:
+      menuItemTypeString = 'lastEdited'
+      title = localizedStrings.menuLastEditedTitle
+      subtitle = localizedStrings.menuLastEditedSubtitle
+      break
+    case FooterMenu.MenuItemType.pageIssues:
+      menuItemTypeString = 'pageIssues'
+      title = localizedStrings.menuPageIssuesTitle
+      break
+    case FooterMenu.MenuItemType.disambiguation:
+      menuItemTypeString = 'disambiguation'
+      title = localizedStrings.menuDisambiguationTitle
+      break
+    case FooterMenu.MenuItemType.coordinate:
+      menuItemTypeString = 'coordinate'
+      title = localizedStrings.menuCoordinateTitle
+      break
+    case FooterMenu.MenuItemType.talkPage:
+      menuItemTypeString = 'talkPage'
+      title = localizedStrings.menuTalkPageTitle
+      break
+    default:
+    }
+
+    /**
+     * @param {!map} payload menu item payload
+     * @return {void}
+     */
+    const itemSelectionHandler = payload => { // TODO: interaction handling
+      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
+    }
+
+    FooterMenu.maybeAddItem(
+      title,
+      subtitle,
+      item,
+      'pagelib_footer_container_menu_items',
+      itemSelectionHandler,
+      document
+    )
+  })
+
+  if (readMoreItemCount && readMoreItemCount > 0) {
+    FooterReadMore.setHeading(
+      localizedStrings.readMoreHeading,
+      'pagelib_footer_container_readmore_heading',
+      document
+    )
+
+    /**
+     * @param {!string} title article title
+     * @return {void}
+     */
+    const saveButtonTapHandler = title => {
+    } // TODO: interaction handling
+
+    /**
+     * @param {!list} titles article titles
+     * @return {void}
+     */
+    const titlesShownHandler = titles => {
+    } // TODO: interaction handling
+
+    FooterReadMore.add(
+      articleTitle,
+      readMoreItemCount,
+      'pagelib_footer_container_readmore_pages',
+      readMoreBaseURL,
+      saveButtonTapHandler,
+      titlesShownHandler,
+      document
+    )
+  }
+
+  /**
+   * @return {void}
+   */
+  const licenseLinkClickHandler = () => {
+  } // TODO: interaction handling
+
+  /**
+   * @return {void}
+   */
+  const viewInBrowserLinkClickHandler = {} // TODO: interaction handling
+
+  FooterLegal.add(
+    document,
+    localizedStrings.licenseString,
+    localizedStrings.licenseSubstitutionString,
+    'pagelib_footer_container_legal',
+    licenseLinkClickHandler,
+    localizedStrings.viewInBrowserString,
+    viewInBrowserLinkClickHandler
+  )
+}
+
+/**
+ * Updates save button text and bookmark icon for saved state in 'Read more' items.
+ * Safe to call even for titles for which there is not currently a 'Read more' item.
+ * @param {!Document} document
+ * @param {!string} title
+ * @param {!string} text
+ * @param {!boolean} isSaved
+ * @return {void}
+ */
+const updateReadMoreSaveButtonForTitle = (document, title, text, isSaved) => {
+  FooterReadMore.updateSaveButtonForTitle(title, text, isSaved, document)
+}
 
 export default {
-  MenuItemType: FooterMenu.MenuItemType
+  MenuItemType: FooterMenu.MenuItemType,
+  add,
+  updateReadMoreSaveButtonForTitle
 }

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -3,6 +3,20 @@ import FooterLegal from '../../transform/FooterLegal'
 import FooterMenu from '../../transform/FooterMenu'
 import FooterReadMore from '../../transform/FooterReadMore'
 
+let handlers
+
+/**
+ * Sets up the interaction handlers for the footer.
+ * @param {!{}} newHandlers an object with handlers for {
+ *   itemSelectionHandler, saveButtonTapHandler, titlesShownHandler, licenseLinkClickHandler,
+ *   viewInBrowserLinkClickHandler
+ * }
+ * @return {void}
+ */
+const _setupInteractionHandlers = newHandlers => {
+  handlers = newHandlers
+}
+
 /**
  * Adds footer to the end of the document
  * @param  {!Document} document
@@ -62,8 +76,10 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
      * @param {!map} payload menu item payload
      * @return {void}
      */
-    const itemSelectionHandler = payload => { // TODO: interaction handling
-      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
+    const itemSelectionHandler = payload => {
+      if (handlers) {
+        handlers.itemSelectionHandler(menuItemTypeString, payload)
+      }
     }
 
     FooterMenu.maybeAddItem(
@@ -88,14 +104,20 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
      * @return {void}
      */
     const saveButtonTapHandler = title => {
-    } // TODO: interaction handling
+      if (handlers) {
+        handlers.saveButtonTapHandler(title)
+      }
+    }
 
     /**
      * @param {!list} titles article titles
      * @return {void}
      */
     const titlesShownHandler = titles => {
-    } // TODO: interaction handling
+      if (handlers) {
+        handlers.titlesShownHandler(titles)
+      }
+    }
 
     FooterReadMore.add(
       articleTitle,
@@ -112,12 +134,19 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
    * @return {void}
    */
   const licenseLinkClickHandler = () => {
-  } // TODO: interaction handling
+    if (handlers) {
+      handlers.licenseLinkClickHandler()
+    }
+  }
 
   /**
    * @return {void}
    */
-  const viewInBrowserLinkClickHandler = {} // TODO: interaction handling
+  const viewInBrowserLinkClickHandler = () => {
+    if (handlers) {
+      handlers.viewInBrowserLinkClickHandler()
+    }
+  }
 
   FooterLegal.add(
     document,
@@ -146,5 +175,6 @@ const updateReadMoreSaveButtonForTitle = (document, title, text, isSaved) => {
 export default {
   MenuItemType: FooterMenu.MenuItemType,
   add,
-  updateReadMoreSaveButtonForTitle
+  updateReadMoreSaveButtonForTitle,
+  _setupInteractionHandlers // to be used internally only
 }

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -134,8 +134,8 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
  * Updates save button text and bookmark icon for saved state in 'Read more' items.
  * Safe to call even for titles for which there is not currently a 'Read more' item.
  * @param {!Document} document
- * @param {!string} title
- * @param {!string} text
+ * @param {!string} title read more entry title
+ * @param {!string} text label indicating saved state
  * @param {!boolean} isSaved
  * @return {void}
  */

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -1,0 +1,5 @@
+import FooterMenu from '../../transform/FooterMenu'
+
+export default {
+  MenuItemType: FooterMenu.MenuItemType
+}

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -154,18 +154,18 @@ const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
  * @param  {!Document} document
  * @param  {!list} articleTitle article title for related pages
  * @param  {!string} menuItems menu items to add
- * @param  {!boolean} hasReadMore whether or not to add read more section
- * @param  {!number} readMoreItemCount number of read more items to add
  * @param  {!map} localizedStrings localized strings
+ * @param  {!number} readMoreItemCount number of read more items to add
+ * @param  {!string} readMoreBaseURL base url for restbase to fetch read more
  * @return {void}
  */
 const addFooter = (
   document,
   articleTitle,
   menuItems,
-  hasReadMore,
+  localizedStrings,
   readMoreItemCount,
-  localizedStrings
+  readMoreBaseURL
 ) => {
   // Add container
   if (FooterContainer.isContainerAttached(document) === false) {
@@ -226,7 +226,7 @@ const addFooter = (
     )
   })
 
-  if (hasReadMore) {
+  if (readMoreItemCount && readMoreItemCount > 0) {
     FooterReadMore.setHeading(
       localizedStrings.readMoreHeading,
       'pagelib_footer_container_readmore_heading',
@@ -246,7 +246,7 @@ const addFooter = (
       articleTitle,
       readMoreItemCount,
       'pagelib_footer_container_readmore_pages',
-      'http://localhost:7231/en.wikipedia.org/v1',
+      readMoreBaseURL,
       saveButtonTapHandler,
       titlesShownHandler,
       document

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -272,6 +272,20 @@ const addFooter = (
   )
 }
 
+
+/**
+ * Updates save button text and bookmark icon for saved state.
+ * Safe to call even for titles for which there is not currently a 'Read more' item.
+ * @param {!Document} document
+ * @param {!string} title
+ * @param {!string} text
+ * @param {!boolean} isSaved
+ * @return {void}
+*/
+const updateSaveButtonForTitle = (document, title, text, isSaved) => {
+  FooterReadMore.updateSaveButtonForTitle(title, text, isSaved, document)
+}
+
 /**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
@@ -282,6 +296,7 @@ const getScroller = () => Scroller
 document.addEventListener('DOMContentLoaded', () => onPageLoad(window, document))
 
 export default {
+  addFooter,
   onPageLoad,
   setMulti,
   setTheme,
@@ -289,7 +304,7 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
-  addFooter,
+  updateSaveButtonForTitle,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -2,6 +2,10 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
+import FooterContainer from '../../transform/FooterContainer'
+import FooterLegal from '../../transform/FooterLegal'
+import FooterMenu from '../../transform/FooterMenu'
+import FooterReadMore from '../../transform/FooterReadMore'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
 import Scroller from './Scroller'
@@ -146,6 +150,129 @@ const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
 }
 
 /**
+ * Adds footer to the end of the document
+ * @param  {!Document} document
+ * @param  {!list} articleTitle article title for related pages
+ * @param  {!string} menuItems menu items to add
+ * @param  {!boolean} hasReadMore whether or not to add read more section
+ * @param  {!number} readMoreItemCount number of read more items to add
+ * @param  {!map} localizedStrings localized strings
+ * @return {void}
+ */
+const addFooter = (
+  document,
+  articleTitle,
+  menuItems,
+  hasReadMore,
+  readMoreItemCount,
+  localizedStrings
+) => {
+  // Add container
+  if (FooterContainer.isContainerAttached(document) === false) {
+    document.body.appendChild(FooterContainer.containerFragment(document))
+  }
+  // Add menu
+  FooterMenu.setHeading(
+    localizedStrings.menuHeading,
+    'pagelib_footer_container_menu_heading',
+    document
+  )
+  menuItems.forEach(item => {
+    let title = ''
+    let subtitle = ''
+    let menuItemTypeString = ''
+    switch (item) {
+    case FooterMenu.MenuItemType.languages:
+      menuItemTypeString = 'languages'
+      title = localizedStrings.menuLanguagesTitle
+      break
+    case FooterMenu.MenuItemType.lastEdited:
+      menuItemTypeString = 'lastEdited'
+      title = localizedStrings.menuLastEditedTitle
+      subtitle = localizedStrings.menuLastEditedSubtitle
+      break
+    case FooterMenu.MenuItemType.pageIssues:
+      menuItemTypeString = 'pageIssues'
+      title = localizedStrings.menuPageIssuesTitle
+      break
+    case FooterMenu.MenuItemType.disambiguation:
+      menuItemTypeString = 'disambiguation'
+      title = localizedStrings.menuDisambiguationTitle
+      break
+    case FooterMenu.MenuItemType.coordinate:
+      menuItemTypeString = 'coordinate'
+      title = localizedStrings.menuCoordinateTitle
+      break
+    case FooterMenu.MenuItemType.talkPage:
+      menuItemTypeString = 'talkPage'
+      title = localizedStrings.menuTalkPageTitle
+      break
+    default:
+    }
+    /**
+    * @param {!map} payload menu item payload
+    * @return {void}
+    */
+    const itemSelectionHandler = payload => { // TODO: interaction handling
+      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
+    }
+    FooterMenu.maybeAddItem(
+      title,
+      subtitle,
+      item,
+      'pagelib_footer_container_menu_items',
+      itemSelectionHandler,
+      document
+    )
+  })
+
+  if (hasReadMore) {
+    FooterReadMore.setHeading(
+      localizedStrings.readMoreHeading,
+      'pagelib_footer_container_readmore_heading',
+      document
+    )
+    /**
+    * @param {!string} title article title
+    * @return {void}
+    */
+    const saveButtonTapHandler = title => { } // TODO: interaction handling
+    /**
+    * @param {!list} titles article titles
+    * @return {void}
+    */
+    const titlesShownHandler = titles => { } // TODO: interaction handling
+    FooterReadMore.add(
+      articleTitle,
+      readMoreItemCount,
+      'pagelib_footer_container_readmore_pages',
+      null,
+      saveButtonTapHandler,
+      titlesShownHandler,
+      document
+    )
+  }
+
+  /**
+  * @return {void}
+  */
+  const licenseLinkClickHandler = () => { } // TODO: interaction handling
+  /**
+  * @return {void}
+  */
+  const viewInBrowserLinkClickHandler =  { } // TODO: interaction handling
+  FooterLegal.add(
+    document,
+    localizedStrings.licenseString,
+    localizedStrings.licenseSubstitutionString,
+    'pagelib_footer_container_legal',
+    licenseLinkClickHandler,
+    localizedStrings.viewInBrowserString,
+    viewInBrowserLinkClickHandler
+  )
+}
+
+/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -162,6 +289,7 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
+  addFooter,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -251,6 +251,8 @@ const addFooter = (
       titlesShownHandler,
       document
     )
+
+    FooterContainer.updateLeftAndRightMargin(18, document) // TODO: integrate with setMargins
   }
 
   /**

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -246,7 +246,7 @@ const addFooter = (
       articleTitle,
       readMoreItemCount,
       'pagelib_footer_container_readmore_pages',
-      null,
+      'http://localhost:7231/en.wikipedia.org/v1',
       saveButtonTapHandler,
       titlesShownHandler,
       document

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -251,8 +251,6 @@ const addFooter = (
       titlesShownHandler,
       document
     )
-
-    FooterContainer.updateLeftAndRightMargin(18, document) // TODO: integrate with setMargins
   }
 
   /**

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -2,10 +2,6 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
-import FooterContainer from '../../transform/FooterContainer'
-import FooterLegal from '../../transform/FooterLegal'
-import FooterMenu from '../../transform/FooterMenu'
-import FooterReadMore from '../../transform/FooterReadMore'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
 import Scroller from './Scroller'
@@ -150,143 +146,6 @@ const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
 }
 
 /**
- * Adds footer to the end of the document
- * @param  {!Document} document
- * @param  {!list} articleTitle article title for related pages
- * @param  {!string} menuItems menu items to add
- * @param  {!map} localizedStrings localized strings
- * @param  {!number} readMoreItemCount number of read more items to add
- * @param  {!string} readMoreBaseURL base url for restbase to fetch read more
- * @return {void}
- */
-const addFooter = (
-  document,
-  articleTitle,
-  menuItems,
-  localizedStrings,
-  readMoreItemCount,
-  readMoreBaseURL
-) => {
-  // Add container
-  if (FooterContainer.isContainerAttached(document) === false) {
-    document.body.appendChild(FooterContainer.containerFragment(document))
-  }
-  // Add menu
-  FooterMenu.setHeading(
-    localizedStrings.menuHeading,
-    'pagelib_footer_container_menu_heading',
-    document
-  )
-  menuItems.forEach(item => {
-    let title = ''
-    let subtitle = ''
-    let menuItemTypeString = ''
-    switch (item) {
-    case FooterMenu.MenuItemType.languages:
-      menuItemTypeString = 'languages'
-      title = localizedStrings.menuLanguagesTitle
-      break
-    case FooterMenu.MenuItemType.lastEdited:
-      menuItemTypeString = 'lastEdited'
-      title = localizedStrings.menuLastEditedTitle
-      subtitle = localizedStrings.menuLastEditedSubtitle
-      break
-    case FooterMenu.MenuItemType.pageIssues:
-      menuItemTypeString = 'pageIssues'
-      title = localizedStrings.menuPageIssuesTitle
-      break
-    case FooterMenu.MenuItemType.disambiguation:
-      menuItemTypeString = 'disambiguation'
-      title = localizedStrings.menuDisambiguationTitle
-      break
-    case FooterMenu.MenuItemType.coordinate:
-      menuItemTypeString = 'coordinate'
-      title = localizedStrings.menuCoordinateTitle
-      break
-    case FooterMenu.MenuItemType.talkPage:
-      menuItemTypeString = 'talkPage'
-      title = localizedStrings.menuTalkPageTitle
-      break
-    default:
-    }
-    /**
-    * @param {!map} payload menu item payload
-    * @return {void}
-    */
-    const itemSelectionHandler = payload => { // TODO: interaction handling
-      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
-    }
-    FooterMenu.maybeAddItem(
-      title,
-      subtitle,
-      item,
-      'pagelib_footer_container_menu_items',
-      itemSelectionHandler,
-      document
-    )
-  })
-
-  if (readMoreItemCount && readMoreItemCount > 0) {
-    FooterReadMore.setHeading(
-      localizedStrings.readMoreHeading,
-      'pagelib_footer_container_readmore_heading',
-      document
-    )
-    /**
-    * @param {!string} title article title
-    * @return {void}
-    */
-    const saveButtonTapHandler = title => { } // TODO: interaction handling
-    /**
-    * @param {!list} titles article titles
-    * @return {void}
-    */
-    const titlesShownHandler = titles => { } // TODO: interaction handling
-    FooterReadMore.add(
-      articleTitle,
-      readMoreItemCount,
-      'pagelib_footer_container_readmore_pages',
-      readMoreBaseURL,
-      saveButtonTapHandler,
-      titlesShownHandler,
-      document
-    )
-  }
-
-  /**
-  * @return {void}
-  */
-  const licenseLinkClickHandler = () => { } // TODO: interaction handling
-  /**
-  * @return {void}
-  */
-  const viewInBrowserLinkClickHandler =  { } // TODO: interaction handling
-  FooterLegal.add(
-    document,
-    localizedStrings.licenseString,
-    localizedStrings.licenseSubstitutionString,
-    'pagelib_footer_container_legal',
-    licenseLinkClickHandler,
-    localizedStrings.viewInBrowserString,
-    viewInBrowserLinkClickHandler
-  )
-}
-
-
-/**
- * Updates save button text and bookmark icon for saved state.
- * Safe to call even for titles for which there is not currently a 'Read more' item.
- * @param {!Document} document
- * @param {!string} title
- * @param {!string} text
- * @param {!boolean} isSaved
- * @return {void}
-*/
-const updateSaveButtonForTitle = (document, title, text, isSaved) => {
-  FooterReadMore.updateSaveButtonForTitle(title, text, isSaved, document)
-}
-
-/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -296,7 +155,6 @@ const getScroller = () => Scroller
 document.addEventListener('DOMContentLoaded', () => onPageLoad(window, document))
 
 export default {
-  addFooter,
   onPageLoad,
   setMulti,
   setTheme,
@@ -304,7 +162,6 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
-  updateSaveButtonForTitle,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/index.js
+++ b/src/pcs/c1/index.js
@@ -1,3 +1,4 @@
+import Footer from './Footer'
 import PageMods from './PageMods'
 import Platforms from './Platforms'
 import Scroller from './Scroller'
@@ -5,8 +6,9 @@ import Sections from './Sections'
 import Themes from './Themes'
 
 export default {
-  Platforms,
+  Footer,
   PageMods,
+  Platforms,
   Scroller,
   Sections,
   Themes

--- a/src/transform/FooterContainer.css
+++ b/src/transform/FooterContainer.css
@@ -2,6 +2,10 @@
   padding-bottom: 1.5em;
 }
 
+.pagelib_footer_section a:hover {
+  text-decoration: none;
+}
+
 .pagelib_footer_container_heading {
 }
 

--- a/src/transform/FooterContainer.css
+++ b/src/transform/FooterContainer.css
@@ -6,24 +6,6 @@
   text-decoration: none;
 }
 
-.pagelib_footer_container_heading {
-}
-
-.pagelib_theme_sepia .pagelib_footer_container_heading {
-}
-
-.pagelib_theme_dark .pagelib_footer_container_heading {
-}
-
-.pagelib_theme_black .pagelib_footer_container_heading {
-}
-
-#pagelib_footer_container_readmore_pages {
-}
-
-#pagelib_footer_container_menu_heading {
-}
-
 #pagelib_footer_container_menu_items {
   background-color: #c8ccd1;
   display: table;

--- a/src/transform/FooterContainer.css
+++ b/src/transform/FooterContainer.css
@@ -1,17 +1,13 @@
 .pagelib_footer_container {
-  background-color: #eaecf0;
 }
 
 .pagelib_theme_dark .pagelib_footer_container {
-  background-color: #222;
 }
 
 .pagelib_theme_sepia .pagelib_footer_container {
-  background-color: #e1dad1;
 }
 
 .pagelib_theme_black .pagelib_footer_container {
-  background-color: #101418;
 }
 
 .pagelib_footer_container_heading {

--- a/src/transform/FooterContainer.css
+++ b/src/transform/FooterContainer.css
@@ -1,13 +1,5 @@
-.pagelib_footer_container {
-}
-
-.pagelib_theme_dark .pagelib_footer_container {
-}
-
-.pagelib_theme_sepia .pagelib_footer_container {
-}
-
-.pagelib_theme_black .pagelib_footer_container {
+.pagelib_footer_section {
+  padding-bottom: 1.5em;
 }
 
 .pagelib_footer_container_heading {
@@ -26,7 +18,6 @@
 }
 
 #pagelib_footer_container_menu_heading {
-  margin-bottom: 10px;
 }
 
 #pagelib_footer_container_menu_items {
@@ -34,7 +25,6 @@
   display: table;
   width: 100%;
   border-collapse: collapse;
-  margin-bottom: 1em;
 }
 
 .pagelib_theme_dark #pagelib_footer_container_menu_items,

--- a/src/transform/FooterContainer.css
+++ b/src/transform/FooterContainer.css
@@ -11,22 +11,15 @@
 }
 
 .pagelib_footer_container_heading {
-  padding-top: 35px;
-  font-size: 0.8em;
-  line-height: 0.8em;
-  color: #72777D;
 }
 
 .pagelib_theme_sepia .pagelib_footer_container_heading {
-  color: #646059;
 }
 
 .pagelib_theme_dark .pagelib_footer_container_heading {
-  color: #C8CCD1;
 }
 
 .pagelib_theme_black .pagelib_footer_container_heading {
-  color: #F8F9FA;
 }
 
 #pagelib_footer_container_readmore_pages {
@@ -41,6 +34,7 @@
   display: table;
   width: 100%;
   border-collapse: collapse;
+  margin-bottom: 1em;
 }
 
 .pagelib_theme_dark #pagelib_footer_container_menu_items,

--- a/src/transform/FooterContainer.js
+++ b/src/transform/FooterContainer.js
@@ -8,13 +8,15 @@ import './FooterContainer.css'
 const containerFragment = document => {
   const containerFragment = document.createDocumentFragment()
   const menuSection = document.createElement('section')
-  menuSection.id = 'pagelib_footer_container_section_0'
+  menuSection.id = 'pagelib_footer_container_menu'
+  menuSection.className = 'pagelib_footer_section'
   menuSection.innerHTML =
   `<h2 id='pagelib_footer_container_menu_heading' class='pagelib_footer_container_heading'></h2>
    <div id='pagelib_footer_container_menu_items'></div>`
   containerFragment.appendChild(menuSection)
   const readMoreSection = document.createElement('section')
   readMoreSection.id = 'pagelib_footer_container_readmore'
+  readMoreSection.className = 'pagelib_footer_section'
   readMoreSection.innerHTML =
   `<h2 id='pagelib_footer_container_readmore_heading' class='pagelib_footer_container_heading'></h2>
    <div id='pagelib_footer_container_readmore_pages'></div>`

--- a/src/transform/FooterContainer.js
+++ b/src/transform/FooterContainer.js
@@ -11,14 +11,14 @@ const containerFragment = document => {
   menuSection.id = 'pagelib_footer_container_menu'
   menuSection.className = 'pagelib_footer_section'
   menuSection.innerHTML =
-  `<h2 id='pagelib_footer_container_menu_heading' class='pagelib_footer_container_heading'></h2>
+  `<h2 id='pagelib_footer_container_menu_heading'></h2>
    <div id='pagelib_footer_container_menu_items'></div>`
   containerFragment.appendChild(menuSection)
   const readMoreSection = document.createElement('section')
   readMoreSection.id = 'pagelib_footer_container_readmore'
   readMoreSection.className = 'pagelib_footer_section'
   readMoreSection.innerHTML =
-  `<h2 id='pagelib_footer_container_readmore_heading' class='pagelib_footer_container_heading'></h2>
+  `<h2 id='pagelib_footer_container_readmore_heading'></h2>
    <div id='pagelib_footer_container_readmore_pages'></div>`
   containerFragment.appendChild(readMoreSection)
   const legalSection = document.createElement('section')

--- a/src/transform/FooterContainer.js
+++ b/src/transform/FooterContainer.js
@@ -1,45 +1,4 @@
 import './FooterContainer.css'
-import Polyfill from './Polyfill'
-
-/**
- * Ensures the 'Read more' section header can always be scrolled to the top of the screen.
- * @param {!Window} window
- * @return {void}
- */
-const updateBottomPaddingToAllowReadMoreToScrollToTop = window => {
-  const div = window.document.getElementById('pagelib_footer_container_ensure_can_scroll_to_top')
-  const currentPadding = parseInt(div.style.paddingBottom, 10) || 0
-  const height = div.clientHeight - currentPadding
-  const newPadding = Math.max(0, window.innerHeight - height)
-  div.style.paddingBottom = `${newPadding}px`
-}
-
-/**
- * Allows native code to adjust footer container margins without having to worry about
- * implementation details.
- * @param {!number} margin
- * @param {!Document} document
- * @return {void}
- */
-const updateLeftAndRightMargin = (margin, document) => {
-  const selectors = [
-    '#pagelib_footer_container_menu_heading',
-    '#pagelib_footer_container_readmore',
-    '#pagelib_footer_container_legal'
-  ]
-  const elements = Polyfill.querySelectorAll(document, selectors.join())
-  elements.forEach(element => {
-    element.style.marginLeft = `${margin}px`
-    element.style.marginRight = `${margin}px`
-  })
-  const rightOrLeft = document.querySelector('html').dir === 'rtl' ? 'right' : 'left'
-  Polyfill.querySelectorAll(document, '.pagelib_footer_menu_item')
-    .forEach(element => {
-      element.style.backgroundPosition = `${rightOrLeft} ${margin}px center`
-      element.style.paddingLeft = `${margin}px`
-      element.style.paddingRight = `${margin}px`
-    })
-}
 
 /**
  * Returns a fragment containing structural footer html which may be inserted where needed.
@@ -47,32 +6,22 @@ const updateLeftAndRightMargin = (margin, document) => {
  * @return {!DocumentFragment}
  */
 const containerFragment = document => {
-  const containerDiv = document.createElement('div')
   const containerFragment = document.createDocumentFragment()
-  containerFragment.appendChild(containerDiv)
-  containerDiv.innerHTML =
-  `<div id='pagelib_footer_container' class='pagelib_footer_container'>
-    <div id='pagelib_footer_container_section_0'>
-      <div id='pagelib_footer_container_menu'>
-        <div id='pagelib_footer_container_menu_heading' class='pagelib_footer_container_heading'>
-        </div>
-        <div id='pagelib_footer_container_menu_items'>
-        </div>
-      </div>
-    </div>
-    <div id='pagelib_footer_container_ensure_can_scroll_to_top'>
-      <div id='pagelib_footer_container_section_1'>
-        <div id='pagelib_footer_container_readmore'>
-          <div
-            id='pagelib_footer_container_readmore_heading' class='pagelib_footer_container_heading'>
-          </div>
-          <div id='pagelib_footer_container_readmore_pages'>
-          </div>
-        </div>
-      </div>
-      <div id='pagelib_footer_container_legal'></div>
-    </div>
-  </div>`
+  const menuSection = document.createElement('section')
+  menuSection.id = 'pagelib_footer_container_section_0'
+  menuSection.innerHTML =
+  `<h2 id='pagelib_footer_container_menu_heading' class='pagelib_footer_container_heading'></h2>
+   <div id='pagelib_footer_container_menu_items'></div>`
+  containerFragment.appendChild(menuSection)
+  const readMoreSection = document.createElement('section')
+  readMoreSection.id = 'pagelib_footer_container_readmore'
+  readMoreSection.innerHTML =
+  `<h2 id='pagelib_footer_container_readmore_heading' class='pagelib_footer_container_heading'></h2>
+   <div id='pagelib_footer_container_readmore_pages'></div>`
+  containerFragment.appendChild(readMoreSection)
+  const legalSection = document.createElement('section')
+  legalSection.id = 'pagelib_footer_container_legal'
+  containerFragment.appendChild(legalSection)
   return containerFragment
 }
 
@@ -85,7 +34,5 @@ const isContainerAttached = document => Boolean(document.querySelector('#pagelib
 
 export default {
   containerFragment,
-  isContainerAttached, // todo: rename isAttached()?
-  updateBottomPaddingToAllowReadMoreToScrollToTop,
-  updateLeftAndRightMargin
+  isContainerAttached // todo: rename isAttached()?
 }

--- a/src/transform/FooterMenu.css
+++ b/src/transform/FooterMenu.css
@@ -19,7 +19,7 @@
   background-color: #222;
 }
 
-html[dir='ltr'] .pagelib_footer_menu_item {
+.pagelib_footer_menu_item {
   background-position: left center;
 }
 
@@ -37,7 +37,7 @@ html[dir='rtl'] .pagelib_footer_menu_item {
   color: #f8f9fa;
 }
 
-html[dir='ltr'] .pagelib_footer_menu_item_title {
+.pagelib_footer_menu_item_title {
   padding-left: 50px;
 }
 
@@ -55,7 +55,7 @@ html[dir='rtl'] .pagelib_footer_menu_item_title {
   color: #7c776e;
 }
 
-html[dir='ltr'] .pagelib_footer_menu_item_subtitle {
+.pagelib_footer_menu_item_subtitle {
   padding-left: 50px;
 }
 

--- a/src/transform/FooterMenu.css
+++ b/src/transform/FooterMenu.css
@@ -19,11 +19,13 @@
   background-color: #222;
 }
 
-.pagelib_footer_menu_item {
+html[dir='ltr'] .pagelib_footer_menu_item,
+body[dir='ltr'] .pagelib_footer_menu_item {
   background-position: left center;
 }
 
-html[dir='rtl'] .pagelib_footer_menu_item {
+html[dir='rtl'] .pagelib_footer_menu_item,
+body[dir='rtl'] .pagelib_footer_menu_item {
   background-position: right center;
 }
 
@@ -37,11 +39,13 @@ html[dir='rtl'] .pagelib_footer_menu_item {
   color: #f8f9fa;
 }
 
-.pagelib_footer_menu_item_title {
+html[dir='ltr'] .pagelib_footer_menu_item_title,
+body[dir='ltr'] .pagelib_footer_menu_item_title {
   padding-left: 50px;
 }
 
-html[dir='rtl'] .pagelib_footer_menu_item_title {
+html[dir='rtl'] .pagelib_footer_menu_item_title,
+body[dir='rtl'] .pagelib_footer_menu_item_title {
   padding-right: 50px;
 }
 
@@ -55,11 +59,13 @@ html[dir='rtl'] .pagelib_footer_menu_item_title {
   color: #7c776e;
 }
 
-.pagelib_footer_menu_item_subtitle {
+html[dir='ltr'] .pagelib_footer_menu_item_subtitle,
+body[dir='ltr'] .pagelib_footer_menu_item_subtitle {
   padding-left: 50px;
 }
 
-html[dir='rtl'] .pagelib_footer_menu_item_subtitle {
+html[dir='rtl'] .pagelib_footer_menu_item_subtitle,
+body[dir='rtl'] .pagelib_footer_menu_item_subtitle {
   padding-right: 50px;
 }
 

--- a/src/transform/FooterReadMore.css
+++ b/src/transform/FooterReadMore.css
@@ -27,10 +27,6 @@
 .pagelib_footer_readmore_page_container {
 }
 
-.pagelib_platform_android #pagelib_footer_container_readmore_heading {
-  font-size: 24px;
-}
-
 .pagelib_footer_readmore_page_title {
   color: #222;
   display: block;

--- a/src/transform/FooterReadMore.css
+++ b/src/transform/FooterReadMore.css
@@ -99,6 +99,7 @@
 }
 
 html[dir='rtl'] .pagelib_footer_readmore_page_save,
+body[dir='rtl'] .pagelib_footer_readmore_page_save,
 .content-rtl .pagelib_footer_readmore_page_save {
   background-position: right center;
 }
@@ -118,6 +119,7 @@ html[dir='rtl'] .pagelib_footer_readmore_page_save,
 }
 
 html[dir='rtl'] .pagelib_footer_readmore_page_image,
+body[dir='rtl'] .pagelib_footer_readmore_page_image
 .content-rtl .pagelib_footer_readmore_page_image {
   float: left;
   margin-right: 8px;


### PR DESCRIPTION
https://phabricator.wikimedia.org/T217352

To test locally with a local instance of restbase running, use:

```
pagelib.c1.PageMods.addFooter(
    document,
    'Knight Lore',  // articleTitle
    [pagelib.c1.Footer.MenuItemType.languages, pagelib.c1.Footer.MenuItemType.lastEdited, pagelib.c1.Footer.MenuItemType.pageIssues, pagelib.c1.Footer.MenuItemType.disambiguation, pagelib.c1.Footer.MenuItemType.talkPage],  // menuItems
    { 
        'readMoreHeading': 'Read more',
        'menuDisambiguationTitle': 'Similar pages',
        'menuLanguagesTitle': 'Available in 9 other languages',
        'menuHeading': 'About this article',
        'menuLastEditedSubtitle': 'Full edit history',
        'menuLastEditedTitle': 'Edited today',
        'licenseString': 'Content is available under $1 unless otherwise noted.',
        'menuTalkPageTitle': 'View talk page',
        'menuPageIssuesTitle': 'Page issues',
        'viewInBrowserString': 'View article in browser',
        'licenseSubstitutionString': 'CC BY-SA 3.0',
        'menuCoordinateTitle': 'View on a map'
     }, // localizedStrings
     3,  // readMoreItemCount
     'http://localhost:7231/en.wikipedia.org/v1' // baseUrl for getting ReadMore items
)
```

And then to add a bookmark icon and text to a single Read more item:
```
pagelib.c1.PageMods.updateReadMoreSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
```

<img width="510" alt="Screen Shot 2019-06-20 at 8 58 04 AM" src="https://user-images.githubusercontent.com/741327/59851074-ae684a00-9339-11e9-959a-1276f91392f5.png">

![out](https://user-images.githubusercontent.com/741327/59855322-c42e3d00-9342-11e9-9f1c-9755acda2e46.gif)

Other notes:
This isn't intended to keep working as it did when bundled with the iOS app. The iOS app can stay on an older version of page library and the newer changes should be solely for mobile-html.