### PR TITLE
New: interaction handlers

### DIFF
--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -157,5 +157,43 @@ Example:
 pagelib.c1.Footer.updateReadMoreSaveButtonForTitle(document, 'Mire Mare', 'Saved for later', true)
 ```
 
+### InteractionHandling
+
+#### setInteractionHandler()
+Sets up callbacks for select events originating from the WebView.
+
+Example for testing:
+```
+pagelib.c1.InteractionHandling.setInteractionHandler((interaction) => { console.log(JSON.stringify(interaction)) })
+```
+
+iOS: 
+```
+pagelib.c1.InteractionHandling.setInteractionHandler((interaction) => { window.webkit.messageHandlers.interaction.postMessage(interaction) })
+```
+
+Android:
+```
+pagelib.c1.InteractionHandling.setInteractionHandler((interaction) => { window.InteractionWebInterface.post(interaction) })
+```
+
+Currently the following actions can be emitted:
+```
+const Actions = {
+  LinkClicked
+  ImageClicked,
+  ReferenceClicked,
+  EditSection,
+  AddTitleDescription,
+  
+  /* Footer related actions: */
+  FooterItemSelected,
+  SaveOtherPage,
+  ReadMoreTitlesRetrieved,
+  ViewLicense,
+  ViewInBrowser,
+}
+```
+
 
 [Page Content Service]: https://www.mediawiki.org/wiki/Page_Content_Service

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -13,7 +13,7 @@ let handlers
  * }
  * @return {void}
  */
-const _setupInteractionHandlers = newHandlers => {
+const _connectHandlers = newHandlers => {
   handlers = newHandlers
 }
 
@@ -176,5 +176,5 @@ export default {
   MenuItemType: FooterMenu.MenuItemType,
   add,
   updateReadMoreSaveButtonForTitle,
-  _setupInteractionHandlers // to be used internally only
+  _connectHandlers // to be used internally only
 }

--- a/src/pcs/c1/Footer.js
+++ b/src/pcs/c1/Footer.js
@@ -8,8 +8,7 @@ let handlers
 /**
  * Sets up the interaction handlers for the footer.
  * @param {!{}} newHandlers an object with handlers for {
- *   itemSelectionHandler, saveButtonTapHandler, titlesShownHandler, licenseLinkClickHandler,
- *   viewInBrowserLinkClickHandler
+ *   titlesRetrieved, footerItemSelected, saveOtherPage, viewLicense, viewInBrowser
  * }
  * @return {void}
  */
@@ -78,7 +77,7 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
      */
     const itemSelectionHandler = payload => {
       if (handlers) {
-        handlers.itemSelectionHandler(menuItemTypeString, payload)
+        handlers.footerItemSelected(menuItemTypeString, payload)
       }
     }
 
@@ -105,7 +104,7 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
      */
     const saveButtonTapHandler = title => {
       if (handlers) {
-        handlers.saveButtonTapHandler(title)
+        handlers.saveOtherPage(title)
       }
     }
 
@@ -115,7 +114,7 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
      */
     const titlesShownHandler = titles => {
       if (handlers) {
-        handlers.titlesShownHandler(titles)
+        handlers.titlesRetrieved(titles)
       }
     }
 
@@ -135,7 +134,7 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
    */
   const licenseLinkClickHandler = () => {
     if (handlers) {
-      handlers.licenseLinkClickHandler()
+      handlers.viewLicense()
     }
   }
 
@@ -144,7 +143,7 @@ const add = (document, articleTitle, menuItems, localizedStrings, readMoreItemCo
    */
   const viewInBrowserLinkClickHandler = () => {
     if (handlers) {
-      handlers.viewInBrowserLinkClickHandler()
+      handlers.viewInBrowser()
     }
   }
 

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -1,0 +1,246 @@
+import CollapseTable from '../../transform/CollapseTable'
+import ReferenceCollection from '../../transform/ReferenceCollection'
+
+/**
+ * Type of actions users can click which may need to be handled by the native side.
+ * @type {!Object}
+ */
+const Actions = {
+  LinkClicked: 'link_clicked',
+  ImageClicked: 'image_clicked',
+  ReferenceClicked: 'reference_clicked',
+  EditSection: 'edit_section',
+  AddTitleDescription: 'add_title_description',
+}
+
+let interactionHandler
+
+/**
+ * Model of an Interaction.
+ */
+class Interaction {
+  /**
+   * @param {!string} action the type of action
+   * @param {?Object.<any>} data details of the action
+   */
+  constructor(action, data) {
+    this.action = action
+    this.data = data
+  }
+}
+
+/**
+ * Type of items users can click which we may need to handle.
+ * @type {!Object}
+ */
+const ItemType = {
+  unknown: 0,
+  link: 1,
+  image: 2,
+  imagePlaceholder: 3,
+  reference: 4
+}
+
+/**
+ * Model of clicked item.
+ * Reminder: separate `target` and `href` properties
+ * needed to handle non-anchor targets such as images.
+ */
+class ClickedItem {
+  /**
+   * @param {!EventTarget} target event target
+   * @param {!string} href
+   */
+  constructor(target, href) {
+    this.target = target
+    this.href = href
+  }
+
+  /**
+   * Determines type of item based on its properties.
+   * @return {!ItemType} Type of the item
+   */
+  type() {
+    if (ReferenceCollection.isCitation(this.href)) {
+      return ItemType.reference
+    } else if (this.target.tagName === 'IMG'
+      && this.target.getAttribute('data-image-gallery') === 'true') {
+      return ItemType.image
+    } else if (this.target.tagName === 'SPAN'
+      && this.target.parentElement.getAttribute('data-data-image-gallery')
+        === 'true') {
+      return ItemType.imagePlaceholder
+    } else if (this.href) {
+      return ItemType.link
+    }
+    return ItemType.unknown
+  }
+}
+
+/**
+ * Posts a message to native land using the interaction handler.
+ * @param {Interaction} interaction the interaction data
+ * @return {void}
+ */
+const postMessage = interaction => {
+  interactionHandler(interaction)
+}
+
+/**
+ * Posts message for a link click.
+ * @param {!string} href url
+ * @return {void}
+ */
+const postMessageForLinkWithHref = href => {
+  if (href[0] === '#') {
+    CollapseTable.expandCollapsedTableIfItContainsElement(
+      document.getElementById(href.substring(1)))
+  }
+  postMessage(new Interaction(Actions.LinkClicked, { href }))
+}
+
+/**
+ * Posts message for an image click.
+ * @param {!Element} target an image element
+ * @return {void}
+ */
+const postMessageForImageWithTarget = target => {
+  postMessage(new Interaction(Actions.ImageClicked, {
+    src: target.getAttribute('src'),
+    // Image should be fetched by time it is tapped,
+    // so naturalWidth and height should be available.
+    width: target.naturalWidth,
+    height: target.naturalHeight,
+    'data-file-width': target.getAttribute('data-file-width'),
+    'data-file-height': target.getAttribute('data-file-height')
+  }))
+}
+
+/**
+ * Posts a message for a lazy load image placeholder click.
+ * @param {!Element} innerPlaceholderSpan
+ * @return {void}
+ */
+const postMessageForImagePlaceholderWithTarget = innerPlaceholderSpan => {
+  const outerSpan = innerPlaceholderSpan.parentElement
+  postMessage(new Interaction(Actions.ImageClicked, {
+    src: outerSpan.getAttribute('data-src'),
+    width: outerSpan.getAttribute('data-width'),
+    height: outerSpan.getAttribute('data-height'),
+    'data-file-width': outerSpan.getAttribute('data-data-file-width'),
+    'data-file-height': outerSpan.getAttribute('data-data-file-height')
+  }))
+}
+
+/**
+ * Use "X", "Y", "Width" and "Height" keys so we can use CGRectMakeWithDictionaryRepresentation in
+ * native land to convert to CGRect.
+ * @param  {!ReferenceItem} referenceItem
+ * @return {void}
+ */
+const reformatReferenceItemRectToBridgeToCGRect = referenceItem => {
+  referenceItem.rect = {
+    X: referenceItem.rect.left,
+    Y: referenceItem.rect.top,
+    Width: referenceItem.rect.width,
+    Height: referenceItem.rect.height
+  }
+}
+
+/**
+ * Posts a message for a reference click.
+ * @param {!Element} target an anchor element
+ * @return {void}
+ */
+const postMessageForReferenceWithTarget = target => {
+  const nearbyReferences = ReferenceCollection.collectNearbyReferences(document, target)
+  nearbyReferences.referencesGroup.forEach(reformatReferenceItemRectToBridgeToCGRect)
+  postMessage(new Interaction(Actions.ReferenceClicked, nearbyReferences))
+}
+
+/**
+ * Post messages to native land for respective click types.
+ * @param  {!ClickedItem} item the item which was clicked on
+ * @return {boolean} `true` if a message was sent, otherwise `false`
+ */
+const postMessageForClickedItem = item => {
+  switch (item.type()) {
+  case ItemType.link:
+    postMessageForLinkWithHref(item.href)
+    break
+  case ItemType.image:
+    postMessageForImageWithTarget(item.target)
+    break
+  case ItemType.imagePlaceholder:
+    postMessageForImagePlaceholderWithTarget(item.target)
+    break
+  case ItemType.reference:
+    postMessageForReferenceWithTarget(item.target)
+    break
+  default:
+    return false
+  }
+  return true
+}
+
+/**
+ * Handler for the click event. Posts messages across the JS bridge to native land.
+ * @param  {Event} event the event being handled
+ * @return {void}
+ */
+const handleClickEvent = event => {
+  const target = event.target
+  if (!target) {
+    return
+  }
+  // Find anchor for non-anchor targets - like images.
+  const anchorForTarget = target.closest('A')
+  if (!anchorForTarget) {
+    return
+  }
+
+  // Handle edit links.
+  if (anchorForTarget.getAttribute('data-action') === 'edit_section') {
+    postMessage(new Interaction(Actions.EditSection,
+      { sectionId: anchorForTarget.getAttribute('data-id') }))
+    return
+  }
+
+  // Handle add title description link.
+  if (anchorForTarget.getAttribute('data-action') === 'add_title_description') {
+    postMessage(new Interaction(Actions.AddTitleDescription))
+    return
+  }
+
+  const href = anchorForTarget.getAttribute('href')
+  if (!href) {
+    return
+  }
+  postMessageForClickedItem(new ClickedItem(target, href))
+}
+
+/**
+ * Sets the interaction handler function.
+ * @param {~Function} myHandlerFunction a platform specific bridge function.
+ * On iOS consider using something like:
+ *   (interaction) => { window.webkit.messageHandlers.interaction.postMessage(interaction) }
+ * On Android consider using something like:
+ *   (interaction) => { window.InteractionWebInterface.post(interaction) }
+ * To test in a browser consider using something like:
+ *   (interaction) => { console.log(JSON.stringify(interaction)) }
+ * @return {void}
+ */
+const setInteractionHandler = myHandlerFunction => {
+  interactionHandler = myHandlerFunction
+
+  // Associate our custom click handler logic with the document `click` event.
+  document.addEventListener('click', event => {
+    event.preventDefault()
+    handleClickEvent(event)
+  }, false)
+}
+
+export default {
+  Actions,
+  setInteractionHandler
+}

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -13,6 +13,8 @@ const Actions = {
   ReferenceClicked: 'reference_clicked',
   EditSection: 'edit_section',
   AddTitleDescription: 'add_title_description',
+
+  /* Footer related actions: */
   FooterItemSelected: 'footer_item_selected',
   SaveOtherPage: 'save_other_page',
   ReadMoreTitlesRetrieved: 'read_more_titles_retrieved',

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -15,7 +15,7 @@ const Actions = {
   AddTitleDescription: 'add_title_description',
   FooterItemSelected: 'footer_item_selected',
   SaveOtherPage: 'save_other_page',
-  ShowReadMorePages: 'show_read_more_pages',
+  ReadMoreTitlesRetrieved: 'read_more_titles_retrieved',
   ViewLicense: 'view_license',
   ViewInBrowser: 'view_in_browser',
 }
@@ -219,7 +219,7 @@ const handleClickEvent = event => {
  * @param {!map} payload menu item payload
  * @return {void}
  */
-const itemSelectionHandler = (itemType, payload) => {
+const footerItemSelected = (itemType, payload) => {
   postMessage(new Interaction(Actions.FooterItemSelected, { itemType, payload }))
 }
 
@@ -227,29 +227,29 @@ const itemSelectionHandler = (itemType, payload) => {
  * @param {!string} title page title
  * @return {void}
  */
-const saveButtonTapHandler = title => {
+const saveOtherPage = title => {
   postMessage(new Interaction(Actions.SaveOtherPage, { title }))
 }
 
 /**
- * @param {!list<string>} titles list of page titles
+ * @param {!list<string>} titles list of 'Read more' page titles
  * @return {void}
  */
-const titlesShownHandler = titles => {
-  postMessage(new Interaction(Actions.SaveOtherPage, { titles }))
+const titlesRetrieved = titles => {
+  postMessage(new Interaction(Actions.ReadMoreTitlesRetrieved, { titles }))
 }
 
 /**
  * @return {void}
  */
-const licenseLinkClickHandler = () => {
+const viewLicense = () => {
   postMessage(new Interaction(Actions.ViewLicense))
 }
 
 /**
  * @return {void}
  */
-const viewInBrowserLinkClickHandler = () => {
+const viewInBrowser = () => {
   postMessage(new Interaction(Actions.ViewInBrowser))
 }
 
@@ -268,11 +268,11 @@ const setInteractionHandler = myHandlerFunction => {
   interactionHandler = myHandlerFunction
 
   Footer._connectHandlers({
-    itemSelectionHandler,
-    saveButtonTapHandler,
-    titlesShownHandler,
-    licenseLinkClickHandler,
-    viewInBrowserLinkClickHandler
+    footerItemSelected,
+    saveOtherPage,
+    titlesRetrieved,
+    viewLicense,
+    viewInBrowser
   })
 
   // Associate our custom click handler logic with the document `click` event.

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -1,4 +1,5 @@
 import CollapseTable from '../../transform/CollapseTable'
+import Footer from './Footer'
 import LazyLoadTransform from '../../transform/LazyLoadTransform'
 import ReferenceCollection from '../../transform/ReferenceCollection'
 
@@ -12,6 +13,11 @@ const Actions = {
   ReferenceClicked: 'reference_clicked',
   EditSection: 'edit_section',
   AddTitleDescription: 'add_title_description',
+  FooterItemSelected: 'footer_item_selected',
+  SaveOtherPage: 'save_other_page',
+  ShowReadMorePages: 'show_read_more_pages',
+  ViewLicense: 'view_license',
+  ViewInBrowser: 'view_in_browser',
 }
 
 let interactionHandler
@@ -209,6 +215,45 @@ const handleClickEvent = event => {
 }
 
 /**
+ * @param {!string} itemType type of footer menu item
+ * @param {!map} payload menu item payload
+ * @return {void}
+ */
+const itemSelectionHandler = (itemType, payload) => {
+  postMessage(new Interaction(Actions.FooterItemSelected, { itemType, payload }))
+}
+
+/**
+ * @param {!string} title page title
+ * @return {void}
+ */
+const saveButtonTapHandler = title => {
+  postMessage(new Interaction(Actions.SaveOtherPage, { title }))
+}
+
+/**
+ * @param {!list<string>} titles list of page titles
+ * @return {void}
+ */
+const titlesShownHandler = titles => {
+  postMessage(new Interaction(Actions.SaveOtherPage, { titles }))
+}
+
+/**
+ * @return {void}
+ */
+const licenseLinkClickHandler = () => {
+  postMessage(new Interaction(Actions.ViewLicense))
+}
+
+/**
+ * @return {void}
+ */
+const viewInBrowserLinkClickHandler = () => {
+  postMessage(new Interaction(Actions.ViewInBrowser))
+}
+
+/**
  * Sets the interaction handler function.
  * @param {~Function} myHandlerFunction a platform specific bridge function.
  * On iOS consider using something like:
@@ -221,6 +266,14 @@ const handleClickEvent = event => {
  */
 const setInteractionHandler = myHandlerFunction => {
   interactionHandler = myHandlerFunction
+
+  Footer._connectHandlers({
+    itemSelectionHandler,
+    saveButtonTapHandler,
+    titlesShownHandler,
+    licenseLinkClickHandler,
+    viewInBrowserLinkClickHandler
+  })
 
   // Associate our custom click handler logic with the document `click` event.
   document.addEventListener('click', event => {

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -133,28 +133,12 @@ const postMessageForImagePlaceholderWithTarget = innerPlaceholderSpan => {
 }
 
 /**
- * Use "X", "Y", "Width" and "Height" keys so we can use CGRectMakeWithDictionaryRepresentation in
- * native land to convert to CGRect.
- * @param  {!ReferenceItem} referenceItem
- * @return {void}
- */
-const reformatReferenceItemRectToBridgeToCGRect = referenceItem => {
-  referenceItem.rect = {
-    X: referenceItem.rect.left,
-    Y: referenceItem.rect.top,
-    Width: referenceItem.rect.width,
-    Height: referenceItem.rect.height
-  }
-}
-
-/**
  * Posts a message for a reference click.
  * @param {!Element} target an anchor element
  * @return {void}
  */
 const postMessageForReferenceWithTarget = target => {
   const nearbyReferences = ReferenceCollection.collectNearbyReferences(document, target)
-  nearbyReferences.referencesGroup.forEach(reformatReferenceItemRectToBridgeToCGRect)
   postMessage(new Interaction(Actions.ReferenceClicked, nearbyReferences))
 }
 

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -1,4 +1,5 @@
 import CollapseTable from '../../transform/CollapseTable'
+import LazyLoadTransform from '../../transform/LazyLoadTransform'
 import ReferenceCollection from '../../transform/ReferenceCollection'
 
 /**
@@ -64,11 +65,15 @@ class ClickedItem {
     if (ReferenceCollection.isCitation(this.href)) {
       return ItemType.reference
     } else if (this.target.tagName === 'IMG'
-      && this.target.getAttribute('data-image-gallery') === 'true') {
+      && (this.target.classList.contains(LazyLoadTransform.CLASSES.IMAGE_LOADED_CLASS)
+          || this.target.classList.contains(LazyLoadTransform.CLASSES.IMAGE_LOADING_CLASS))
+      && (this.target.closest('figure') || this.target.closest('figure-inline'))
+    ) {
       return ItemType.image
     } else if (this.target.tagName === 'SPAN'
-      && this.target.parentElement.getAttribute('data-data-image-gallery')
-        === 'true') {
+      && this.target.classList.contains(LazyLoadTransform.CLASSES.PLACEHOLDER_CLASS)
+      && (this.target.closest('figure') || this.target.closest('figure-inline'))
+    ) {
       return ItemType.imagePlaceholder
     } else if (this.href) {
       return ItemType.link

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -2,6 +2,10 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
+import FooterContainer from '../../transform/FooterContainer'
+import FooterLegal from '../../transform/FooterLegal'
+import FooterMenu from '../../transform/FooterMenu'
+import FooterReadMore from '../../transform/FooterReadMore'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
 import Scroller from './Scroller'
@@ -146,6 +150,129 @@ const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
 }
 
 /**
+ * Adds footer to the end of the document
+ * @param  {!Document} document
+ * @param  {!list} articleTitle article title for related pages
+ * @param  {!string} menuItems menu items to add
+ * @param  {!boolean} hasReadMore whether or not to add read more section
+ * @param  {!number} readMoreItemCount number of read more items to add
+ * @param  {!map} localizedStrings localized strings
+ * @return {void}
+ */
+const addFooter = (
+  document,
+  articleTitle,
+  menuItems,
+  hasReadMore,
+  readMoreItemCount,
+  localizedStrings
+) => {
+  // Add container
+  if (FooterContainer.isContainerAttached(document) === false) {
+    document.body.appendChild(FooterContainer.containerFragment(document))
+  }
+  // Add menu
+  FooterMenu.setHeading(
+    localizedStrings.menuHeading,
+    'pagelib_footer_container_menu_heading',
+    document
+  )
+  menuItems.forEach(item => {
+    let title = ''
+    let subtitle = ''
+    let menuItemTypeString = ''
+    switch (item) {
+    case FooterMenu.MenuItemType.languages:
+      menuItemTypeString = 'languages'
+      title = localizedStrings.menuLanguagesTitle
+      break
+    case FooterMenu.MenuItemType.lastEdited:
+      menuItemTypeString = 'lastEdited'
+      title = localizedStrings.menuLastEditedTitle
+      subtitle = localizedStrings.menuLastEditedSubtitle
+      break
+    case FooterMenu.MenuItemType.pageIssues:
+      menuItemTypeString = 'pageIssues'
+      title = localizedStrings.menuPageIssuesTitle
+      break
+    case FooterMenu.MenuItemType.disambiguation:
+      menuItemTypeString = 'disambiguation'
+      title = localizedStrings.menuDisambiguationTitle
+      break
+    case FooterMenu.MenuItemType.coordinate:
+      menuItemTypeString = 'coordinate'
+      title = localizedStrings.menuCoordinateTitle
+      break
+    case FooterMenu.MenuItemType.talkPage:
+      menuItemTypeString = 'talkPage'
+      title = localizedStrings.menuTalkPageTitle
+      break
+    default:
+    }
+    /**
+    * @param {!map} payload menu item payload
+    * @return {void}
+    */
+    const itemSelectionHandler = payload => { // TODO: interaction handling
+      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
+    }
+    FooterMenu.maybeAddItem(
+      title,
+      subtitle,
+      item,
+      'pagelib_footer_container_menu_items',
+      itemSelectionHandler,
+      document
+    )
+  })
+
+  if (hasReadMore) {
+    FooterReadMore.setHeading(
+      localizedStrings.readMoreHeading,
+      'pagelib_footer_container_readmore_heading',
+      document
+    )
+    /**
+    * @param {!string} title article title
+    * @return {void}
+    */
+    const saveButtonTapHandler = title => { } // TODO: interaction handling
+    /**
+    * @param {!list} titles article titles
+    * @return {void}
+    */
+    const titlesShownHandler = titles => { } // TODO: interaction handling
+    FooterReadMore.add(
+      articleTitle,
+      readMoreItemCount,
+      'pagelib_footer_container_readmore_pages',
+      null,
+      saveButtonTapHandler,
+      titlesShownHandler,
+      document
+    )
+  }
+
+  /**
+  * @return {void}
+  */
+  const licenseLinkClickHandler = () => { } // TODO: interaction handling
+  /**
+  * @return {void}
+  */
+  const viewInBrowserLinkClickHandler =  { } // TODO: interaction handling
+  FooterLegal.add(
+    document,
+    localizedStrings.licenseString,
+    localizedStrings.licenseSubstitutionString,
+    'pagelib_footer_container_legal',
+    licenseLinkClickHandler,
+    localizedStrings.viewInBrowserString,
+    viewInBrowserLinkClickHandler
+  )
+}
+
+/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -162,6 +289,7 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
+  addFooter,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/index.js
+++ b/src/pcs/c1/index.js
@@ -1,3 +1,4 @@
+import InteractionHandling from './InteractionHandling'
 import Footer from './Footer'
 import PageMods from './PageMods'
 import Platforms from './Platforms'
@@ -7,6 +8,7 @@ import Themes from './Themes'
 
 export default {
   Footer,
+  InteractionHandling,
   Platforms,
   PageMods,
   Scroller,

--- a/src/pcs/c1/index.js
+++ b/src/pcs/c1/index.js
@@ -1,5 +1,5 @@
-import InteractionHandling from './InteractionHandling'
 import Footer from './Footer'
+import InteractionHandling from './InteractionHandling'
 import PageMods from './PageMods'
 import Platforms from './Platforms'
 import Scroller from './Scroller'

--- a/src/pcs/c1/index.js
+++ b/src/pcs/c1/index.js
@@ -7,8 +7,8 @@ import Themes from './Themes'
 
 export default {
   Footer,
-  PageMods,
   Platforms,
+  PageMods,
   Scroller,
   Sections,
   Themes

--- a/src/transform/FooterMenu.js
+++ b/src/transform/FooterMenu.js
@@ -160,7 +160,7 @@ const maybeAddItem = (title, subtitle, itemType, containerID, clickHandler, docu
   // Items are not added if they have a payload extractor which fails to extract anything.
   const extractor = item.payloadExtractor()
   if (extractor) {
-    item.payload = extractor(document, document.querySelector('div#content_block_0'))
+    item.payload = extractor(document, document.querySelector('section[data-mw-section-id="0"]'))
     if (item.payload.length === 0) {
       return
     }

--- a/src/transform/LazyLoadTransform.ts
+++ b/src/transform/LazyLoadTransform.ts
@@ -14,6 +14,15 @@ const PLACEHOLDER_ERROR_CLASS = 'pagelib_lazy_load_placeholder_error' // Downloa
 const IMAGE_LOADING_CLASS = 'pagelib_lazy_load_image_loading' // Download started.
 const IMAGE_LOADED_CLASS = 'pagelib_lazy_load_image_loaded' // Download completed.
 
+const CLASSES = {
+  PLACEHOLDER_CLASS,
+  PLACEHOLDER_PENDING_CLASS,
+  PLACEHOLDER_LOADING_CLASS,
+  PLACEHOLDER_ERROR_CLASS,
+  IMAGE_LOADING_CLASS,
+  IMAGE_LOADED_CLASS
+}
+
 // Attributes copied from images to placeholders via data-* attributes for later restoration. The
 // image's classes and dimensions are also set on the placeholder.
 // The 3 data-* items are used by iOS.
@@ -165,6 +174,7 @@ const loadPlaceholder = (document: Document, placeholder: HTMLSpanElement): HTML
 }
 
 export default {
+  CLASSES,
   PLACEHOLDER_CLASS,
   queryLazyLoadableImages,
   convertImagesToPlaceholders,


### PR DESCRIPTION
for dealing with clicks events or other interactions originating in the WebView that need to be propagated to the native side.

For testing:
```
pagelib.c1.InteractionHandling.setInteractionHandler((interaction) => { console.log(JSON.stringify(interaction)) })
```
then do some interactions (click on links, references, images, ...). Observe the output in the web console.

iOS: 
```
(interaction) => { window.webkit.messageHandlers.interaction.postMessage(interaction) }
```

Android:
```
 (interaction) => { window.InteractionWebInterface.post(interaction) }
```

QA:
Open example page: http://localhost:6927/en.wikipedia.org/v1/page/mobile-html/Video

```
pagelib.c1.InteractionHandling.setInteractionHandler((interaction) => { console.log(JSON.stringify(interaction)) })

pagelib.c1.Footer.add(
    document,
    'Video',  // articleTitle
    [pagelib.c1.Footer.MenuItemType.languages, pagelib.c1.Footer.MenuItemType.lastEdited, pagelib.c1.Footer.MenuItemType.pageIssues, pagelib.c1.Footer.MenuItemType.disambiguation, pagelib.c1.Footer.MenuItemType.talkPage],  // menuItems
    {
        'readMoreHeading': 'Read more',
        'menuDisambiguationTitle': 'Similar pages',
        'menuLanguagesTitle': 'Available in 9 other languages',
        'menuHeading': 'About this article',
        'menuLastEditedSubtitle': 'Full edit history',
        'menuLastEditedTitle': 'Edited today',
        'licenseString': 'Content is available under $1 unless otherwise noted.',
        'menuTalkPageTitle': 'View talk page',
        'menuPageIssuesTitle': 'Page issues',
        'viewInBrowserString': 'View article in browser',
        'licenseSubstitutionString': 'CC BY-SA 3.0',
        'menuCoordinateTitle': 'View on a map'
     }, // localizedStrings
     3,  // readMoreItemCount
     'http://localhost:7231/en.wikipedia.org/v1' // baseUrl for getting ReadMore items
)
```

should get something like this in the console:
```
{"action":"read_more_titles_retrieved","data":{"titles":["Progressive segmented frame","Analog high-definition television system","Multiple sub-Nyquist sampling encoding"]}}
```

Change bookmark icon:
```
pagelib.c1.Footer.updateReadMoreSaveButtonForTitle(document, 'Progressive segmented frame' /* or another read more title */, 'Save for offline', false)
```
Observe the bookmark icon is shown.

Click on the bookmark icon.
```
{"action":"save_other_page","data":{"title":"Progressive segmented frame"}}
```

Click on all footer menu items. (Only 'Page Issues' and 'Similar pages' have a non-empty payload.)

Click on links, references, section edit pencils, images.