### PR TITLE
Fix appearance of spans with specific background color

### DIFF
--- a/demo/DemoArticles/ArticleRef.js
+++ b/demo/DemoArticles/ArticleRef.js
@@ -135,14 +135,14 @@ class ArticleRef {
    * @param {!string} dataFilePath
    * @return {!Promise}
    */
-  fetchSectionsJSON(dataFilePath) {
-    return fetch(`${dataFilePath}${this.fileName()}`)
+  fetchSectionsJSON() {
+    return fetch(`${DEMO_ARTICLES_DATA_PATH}${this.fileName()}`)
       .then(resp => resp.json())
       .then(json => this.sectionsArrayFromJSON(json))
   }
 
-  fetchPageText(dataFilePath) {
-    return fetch(`${dataFilePath}${this.fileName()}`)
+  fetchPageText() {
+    return fetch(`${DEMO_ARTICLES_DATA_PATH}${this.fileName()}`)
       .then(resp => resp.text())
   }
 

--- a/demo/ThemeTransform.html
+++ b/demo/ThemeTransform.html
@@ -148,7 +148,6 @@ const addArticleTitles = articleRefs => {
 
 const DEMO_ARTICLES_PATH = './DemoArticles/'
 const DEMO_ARTICLES_INDEX_PATH = `${DEMO_ARTICLES_PATH}articles.json`
-const DEMO_ARTICLES_DATA_PATH = `${DEMO_ARTICLES_PATH}data/`
 
 /**
  * Promises for fetching article section JSON arrays from local data files for ArticleRefs.
@@ -156,7 +155,7 @@ const DEMO_ARTICLES_DATA_PATH = `${DEMO_ARTICLES_PATH}data/`
  * @return {!Array<Promise>}
  */
 const fetchSectionsJSONForArticleRefs = articleRefs =>
-  articleRefs.map(articleRef => articleRef.fetchSectionsJSON(DEMO_ARTICLES_DATA_PATH))
+  articleRefs.map(articleRef => articleRef.fetchSectionsJSON())
 
 /**
  * Attaches anchor elements to the menu.

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -27,6 +27,10 @@ styles with only the things which need tweaking.
   color: #36c;
 }
 
+.pagelib_theme_div_do_not_apply_baseline {
+  color: #000;
+}
+
 /* external anchor */
 .pagelib_theme_dark a.external,
 .pagelib_theme_sepia a.external,

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -93,7 +93,8 @@ const classifyElements = element => {
     '.PieChartTemplate div',
     '.BarChartTemplate div',
     '.StackedBarTemplate td',
-    '.chess-board div'
+    '.chess-board div',
+    'span[style*="background"]'
   ].join()
   Polyfill.querySelectorAll(element, selector).forEach(element =>
     element.classList.add(CONSTRAINT.DIV_DO_NOT_APPLY_BASELINE))


### PR DESCRIPTION
- If a span has an inline style for the background, preserve the background color by applying the `pagelib_theme_div_do_not_apply_baseline` class
- Set the `color` of `pagelib_theme_div_do_not_apply_baseline` to black since that's the assumed text color from the base css. Without this, the text could be set to a light color on dark themes on the background color that was intended for use with black text.

Before:
![Simulator Screen Shot - iPhone X - 2019-06-26 at 08 49 45](https://user-images.githubusercontent.com/741327/60536501-63a0e780-9cd4-11e9-9cab-3f323dc3658a.png)

After:
![Simulator Screen Shot - iPhone X - 2019-06-26 at 08 49 17](https://user-images.githubusercontent.com/741327/60536508-67346e80-9cd4-11e9-8dc9-6e8869810381.png)
