### PR TITLE
L10n

### DIFF
--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -51,26 +51,29 @@ Combination of the following calls, changing multiple settings in one single cal
 Setting parameter object fields:
 - platform: possible values in pagelib.c1.Platforms: [IOS, ANDROID] 
 - clientVersion: string of client version (platform specific)
+- l10n: object of localized user visible strings: { addTitleDescription }
 - theme: possible values in pagelib.c1.Themes: [DEFAULT, SEPIA, DARK, BLACK]
 - dimImages: boolean
 - margins: object with { top, right, bottom, left }
 - areTablesCollapsed: boolean
 - scrollTop: number of pixel for highest position to scroll to. Use this to adjust for any decor overlaying the viewport.
 
-(The first three field don't have any equivalent separate call since those don't make sense to change after the fact.)
+(The first three fields don't have any equivalent separate call since those don't make sense to change after the fact.)
 
 Example:
 ```
 pagelib.c1.PageMods.setMulti(document, {
   platform: pagelib.c1.Platforms.IOS,
   clientVersion: '6.2.1',
+  l10n: { 
+    addTitleDescription: 'Titelbeschreibung bearbeiten',
+  },
   theme: pagelib.c1.Themes.SEPIA,
   dimImages: true,
   margins: { top: '32px', right: '32px', bottom: '32px', left: '32px' },
   areTablesCollapsed: true,
   scrollTop: 64
-  }, () => { alert('success') }
-)
+})
 ```
 
 #### setTheme()

--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -51,7 +51,7 @@ Combination of the following calls, changing multiple settings in one single cal
 Setting parameter object fields:
 - platform: possible values in pagelib.c1.Platforms: [IOS, ANDROID] 
 - clientVersion: string of client version (platform specific)
-- l10n: object of localized user visible strings: { addTitleDescription }
+- l10n: object of localized user visible strings: { addTitleDescription, tableInfobox, tableOther, tableClose }
 - theme: possible values in pagelib.c1.Themes: [DEFAULT, SEPIA, DARK, BLACK]
 - dimImages: boolean
 - margins: object with { top, right, bottom, left }

--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -67,6 +67,9 @@ pagelib.c1.PageMods.setMulti(document, {
   clientVersion: '6.2.1',
   l10n: { 
     addTitleDescription: 'Titelbeschreibung bearbeiten',
+    tableInfobox: 'Schnelle Fakten',
+    tableOther: 'Weitere Informationen',
+    tableClose: 'Schließen'
   },
   theme: pagelib.c1.Themes.SEPIA,
   dimImages: true,

--- a/src/pcs/c1/L10N.js
+++ b/src/pcs/c1/L10N.js
@@ -4,15 +4,16 @@ import EditTransform from '../../transform/EditTransform'
  * Change user visible labels in the WebView.
  * @param {!Document} document
  * @param {!{string}} localizedStrings a dictionary of localized strings {
- *   add_title_description
+ *   addTitleDescription
  * }
  * @return {void}
  */
 const localizeLabels = (document, localizedStrings) => {
-  if (localizedStrings.add_title_description) {
-    document.querySelector(
-      `[${EditTransform.DATA_ATTRIBUTE.ACTION}=${EditTransform.ACTION_ADD_TITLE_DESCRIPTION}]`)
-      .innerHTML = localizedStrings.add_title_description
+  if (localizedStrings.addTitleDescription) {
+    const element = document.querySelector(`#${EditTransform.ADD_TITLE_DESCRIPTION}`)
+    if (element) {
+      element.innerHTML = localizedStrings.addTitleDescription
+    }
   }
 }
 

--- a/src/pcs/c1/L10N.js
+++ b/src/pcs/c1/L10N.js
@@ -1,5 +1,9 @@
 import EditTransform from '../../transform/EditTransform'
 
+const selectors = {
+  addTitleDescription: `#${EditTransform.ADD_TITLE_DESCRIPTION}`,
+}
+
 /**
  * Change user visible labels in the WebView.
  * @param {!Document} document
@@ -9,10 +13,12 @@ import EditTransform from '../../transform/EditTransform'
  * @return {void}
  */
 const localizeLabels = (document, localizedStrings) => {
-  if (localizedStrings.addTitleDescription) {
-    const element = document.querySelector(`#${EditTransform.ADD_TITLE_DESCRIPTION}`)
-    if (element) {
-      element.innerHTML = localizedStrings.addTitleDescription
+  for (const [key, selector] of Object.entries(selectors)) {
+    if (localizedStrings[key]) {
+      const elements = document.querySelectorAll(selector)
+      elements.forEach(element => {
+        element.innerHTML = localizedStrings[key]
+      })
     }
   }
 }

--- a/src/pcs/c1/L10N.js
+++ b/src/pcs/c1/L10N.js
@@ -1,0 +1,21 @@
+import EditTransform from '../../transform/EditTransform'
+
+/**
+ * Change user visible labels in the WebView.
+ * @param {!Document} document
+ * @param {!{string}} localizedStrings a dictionary of localized strings {
+ *   add_title_description
+ * }
+ * @return {void}
+ */
+const localizeLabels = (document, localizedStrings) => {
+  if (localizedStrings.add_title_description) {
+    document.querySelector(
+      `[${EditTransform.DATA_ATTRIBUTE.ACTION}=${EditTransform.ACTION_ADD_TITLE_DESCRIPTION}]`)
+      .innerHTML = localizedStrings.add_title_description
+  }
+}
+
+export default {
+  localizeLabels
+}

--- a/src/pcs/c1/L10N.js
+++ b/src/pcs/c1/L10N.js
@@ -1,24 +1,28 @@
+import CollapseTable from '../../transform/CollapseTable'
 import EditTransform from '../../transform/EditTransform'
 
 const selectors = {
   addTitleDescription: `#${EditTransform.ADD_TITLE_DESCRIPTION}`,
+  tableInfobox: `.${CollapseTable.CLASS.TABLE_INFOBOX}`,
+  tableOther: `.${CollapseTable.CLASS.TABLE_OTHER}`,
+  tableClose: `.${CollapseTable.CLASS.COLLAPSED_BOTTOM}`,
 }
 
 /**
  * Change user visible labels in the WebView.
  * @param {!Document} document
  * @param {!{string}} localizedStrings a dictionary of localized strings {
- *   addTitleDescription
+ *   addTitleDescription, tableInfobox, tableOther, tableClose
  * }
  * @return {void}
  */
 const localizeLabels = (document, localizedStrings) => {
   for (const [key, selector] of Object.entries(selectors)) {
     if (localizedStrings[key]) {
-      const elements = document.querySelectorAll(selector)
-      elements.forEach(element => {
+      const elements = Array.from(document.querySelectorAll(selector))
+      for (const element of elements) {
         element.innerHTML = localizedStrings[key]
-      })
+      }
     }
   }
 }

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -2,10 +2,6 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
-import FooterContainer from '../../transform/FooterContainer'
-import FooterLegal from '../../transform/FooterLegal'
-import FooterMenu from '../../transform/FooterMenu'
-import FooterReadMore from '../../transform/FooterReadMore'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
 import Scroller from './Scroller'
@@ -150,129 +146,6 @@ const setTextSizeAdjustmentPercentage = (document, textSize, onSuccess) => {
 }
 
 /**
- * Adds footer to the end of the document
- * @param  {!Document} document
- * @param  {!list} articleTitle article title for related pages
- * @param  {!string} menuItems menu items to add
- * @param  {!boolean} hasReadMore whether or not to add read more section
- * @param  {!number} readMoreItemCount number of read more items to add
- * @param  {!map} localizedStrings localized strings
- * @return {void}
- */
-const addFooter = (
-  document,
-  articleTitle,
-  menuItems,
-  hasReadMore,
-  readMoreItemCount,
-  localizedStrings
-) => {
-  // Add container
-  if (FooterContainer.isContainerAttached(document) === false) {
-    document.body.appendChild(FooterContainer.containerFragment(document))
-  }
-  // Add menu
-  FooterMenu.setHeading(
-    localizedStrings.menuHeading,
-    'pagelib_footer_container_menu_heading',
-    document
-  )
-  menuItems.forEach(item => {
-    let title = ''
-    let subtitle = ''
-    let menuItemTypeString = ''
-    switch (item) {
-    case FooterMenu.MenuItemType.languages:
-      menuItemTypeString = 'languages'
-      title = localizedStrings.menuLanguagesTitle
-      break
-    case FooterMenu.MenuItemType.lastEdited:
-      menuItemTypeString = 'lastEdited'
-      title = localizedStrings.menuLastEditedTitle
-      subtitle = localizedStrings.menuLastEditedSubtitle
-      break
-    case FooterMenu.MenuItemType.pageIssues:
-      menuItemTypeString = 'pageIssues'
-      title = localizedStrings.menuPageIssuesTitle
-      break
-    case FooterMenu.MenuItemType.disambiguation:
-      menuItemTypeString = 'disambiguation'
-      title = localizedStrings.menuDisambiguationTitle
-      break
-    case FooterMenu.MenuItemType.coordinate:
-      menuItemTypeString = 'coordinate'
-      title = localizedStrings.menuCoordinateTitle
-      break
-    case FooterMenu.MenuItemType.talkPage:
-      menuItemTypeString = 'talkPage'
-      title = localizedStrings.menuTalkPageTitle
-      break
-    default:
-    }
-    /**
-    * @param {!map} payload menu item payload
-    * @return {void}
-    */
-    const itemSelectionHandler = payload => { // TODO: interaction handling
-      console.log(menuItemTypeString + JSON.stringify(payload)) // eslint-disable-line no-console
-    }
-    FooterMenu.maybeAddItem(
-      title,
-      subtitle,
-      item,
-      'pagelib_footer_container_menu_items',
-      itemSelectionHandler,
-      document
-    )
-  })
-
-  if (hasReadMore) {
-    FooterReadMore.setHeading(
-      localizedStrings.readMoreHeading,
-      'pagelib_footer_container_readmore_heading',
-      document
-    )
-    /**
-    * @param {!string} title article title
-    * @return {void}
-    */
-    const saveButtonTapHandler = title => { } // TODO: interaction handling
-    /**
-    * @param {!list} titles article titles
-    * @return {void}
-    */
-    const titlesShownHandler = titles => { } // TODO: interaction handling
-    FooterReadMore.add(
-      articleTitle,
-      readMoreItemCount,
-      'pagelib_footer_container_readmore_pages',
-      null,
-      saveButtonTapHandler,
-      titlesShownHandler,
-      document
-    )
-  }
-
-  /**
-  * @return {void}
-  */
-  const licenseLinkClickHandler = () => { } // TODO: interaction handling
-  /**
-  * @return {void}
-  */
-  const viewInBrowserLinkClickHandler =  { } // TODO: interaction handling
-  FooterLegal.add(
-    document,
-    localizedStrings.licenseString,
-    localizedStrings.licenseSubstitutionString,
-    'pagelib_footer_container_legal',
-    licenseLinkClickHandler,
-    localizedStrings.viewInBrowserString,
-    viewInBrowserLinkClickHandler
-  )
-}
-
-/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -289,7 +162,6 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
-  addFooter,
   testing: {
     getScroller
   }

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -2,6 +2,7 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
+import L10N from './L10N'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
 import Scroller from './Scroller'
@@ -34,7 +35,7 @@ const onPageLoad = (window, document) => {
  * during initial page load.
  * @param {!Document} document
  * @param {!{}} settings client settings
- *   { platform, clientVersion, theme, dimImages, margins, areTablesCollapsed, scrollTop,
+ *   { platform, clientVersion, l10n, theme, dimImages, margins, areTablesCollapsed, scrollTop,
  *   textSizeAdjustmentPercentage }
  * @param {?PageMods~Function} onSuccess callback
  * @return {void}
@@ -42,6 +43,9 @@ const onPageLoad = (window, document) => {
 const setMulti = (document, settings, onSuccess) => {
   if (settings.platform !== undefined) {
     PlatformTransform.setPlatform(document, settings.platform)
+  }
+  if (settings.l10n !== undefined) {
+    L10N.localizeLabels(document, settings.l10n)
   }
   if (settings.theme !== undefined) {
     ThemeTransform.setTheme(document, settings.theme)

--- a/src/pcs/c1/index.js
+++ b/src/pcs/c1/index.js
@@ -1,5 +1,6 @@
 import Footer from './Footer'
 import InteractionHandling from './InteractionHandling'
+import L10N from './L10N'
 import PageMods from './PageMods'
 import Platforms from './Platforms'
 import Scroller from './Scroller'
@@ -9,6 +10,7 @@ import Themes from './Themes'
 export default {
   Footer,
   InteractionHandling,
+  L10N,
   Platforms,
   PageMods,
   Scroller,

--- a/src/transform/CollapseTable.js
+++ b/src/transform/CollapseTable.js
@@ -15,6 +15,8 @@ const CLASS = {
   COLLAPSED_BOTTOM: 'pagelib_collapse_table_collapsed_bottom',
   COLLAPSE_TEXT: 'pagelib_collapse_table_collapse_text',
   EXPANDED: 'pagelib_collapse_table_expanded',
+  TABLE_INFOBOX: 'pagelib_table_infobox',
+  TABLE_OTHER: 'pagelib_table_other'
 }
 
 /**
@@ -284,14 +286,16 @@ const newCollapsedFooterDiv = (document, content) => {
 /**
  * @param {!Document} document
  * @param {!string} title
+ * @param {!string} titleClass
  * @param {!Array.<string>} headerText
  * @return {!DocumentFragment}
  */
-const newCaptionFragment = (document, title, headerText) => {
+const newCaptionFragment = (document, title, titleClass, headerText) => {
   const fragment = document.createDocumentFragment()
 
   const strong = document.createElement('strong')
   strong.innerHTML = title
+  strong.classList.add(titleClass)
   fragment.appendChild(strong)
 
   const span = document.createElement('span')
@@ -333,7 +337,11 @@ const prepareTables = (document, pageTitle, infoboxTitle, otherTitle, footerTitl
       continue
     }
     const captionFragment =
-      newCaptionFragment(document, isInfobox(table) ? infoboxTitle : otherTitle, headerTextArray)
+      newCaptionFragment(
+        document,
+        isInfobox(table) ? infoboxTitle : otherTitle,
+        isInfobox(table) ? CLASS.TABLE_INFOBOX : CLASS.TABLE_OTHER,
+        headerTextArray)
 
     // create the container div that will contain both the original table
     // and the collapsed version.
@@ -474,6 +482,7 @@ const expandCollapsedTableIfItContainsElement = element => {
 }
 
 export default {
+  CLASS,
   SECTION_TOGGLED_EVENT_TYPE,
   toggleCollapsedForAll,
   toggleCollapseClickCallback,

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -151,8 +151,7 @@ const newEditLeadSectionHeader = (document, pageDisplayTitle, titleDescription,
 
 export default {
   CLASS,
-  ACTION_ADD_TITLE_DESCRIPTION,
-  DATA_ATTRIBUTE,
+  ADD_TITLE_DESCRIPTION: IDS.ADD_TITLE_DESCRIPTION,
   newEditSectionButton,
   newEditSectionHeader,
   newEditLeadSectionHeader

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -151,6 +151,8 @@ const newEditLeadSectionHeader = (document, pageDisplayTitle, titleDescription,
 
 export default {
   CLASS,
+  ACTION_ADD_TITLE_DESCRIPTION,
+  DATA_ATTRIBUTE,
   newEditSectionButton,
   newEditSectionHeader,
   newEditLeadSectionHeader

--- a/test/pcs/c1/L10N.test.js
+++ b/test/pcs/c1/L10N.test.js
@@ -7,12 +7,32 @@ const L10N = c1.L10N
 describe('pcs.c1.L10N', () => {
   describe('.localizeLabels()', () => {
     it('addTitleDescription', () => {
-      const window = domino.createWindow(
+      const document = domino.createDocument(
         '<p id="pagelib_edit_section_add_title_description">before</p>')
-      const document = window.document
 
-      L10N.localizeLabels(document, { addTitleDescription: 'after' })
-      assert.strictEqual(document.body.querySelector('p').innerHTML, 'after')
+      L10N.localizeLabels(document, { addTitleDescription: 'addTitleDescription' })
+      assert.strictEqual(document.body.querySelector('p').innerHTML, 'addTitleDescription')
+    })
+    it('tableInfobox', () => {
+      const document = domino.createDocument(
+        '<strong class="pagelib_table_infobox">Quick facts</strong>')
+
+      L10N.localizeLabels(document, { tableInfobox: 'tableInfobox' })
+      assert.strictEqual(document.body.querySelector('strong').innerHTML, 'tableInfobox')
+    })
+    it('tableOther', () => {
+      const document = domino.createDocument(
+        '<strong class="pagelib_table_other">More information</strong>')
+
+      L10N.localizeLabels(document, { tableOther: 'tableOther' })
+      assert.strictEqual(document.body.querySelector('strong').innerHTML, 'tableOther')
+    })
+    it('tableClose', () => {
+      const document = domino.createDocument(
+        '<div class="pagelib_collapse_table_collapsed_bottom">Close</div>')
+
+      L10N.localizeLabels(document, { tableClose: 'tableClose' })
+      assert.strictEqual(document.body.querySelector('div').innerHTML, 'tableClose')
     })
   })
 })

--- a/test/pcs/c1/L10N.test.js
+++ b/test/pcs/c1/L10N.test.js
@@ -4,16 +4,15 @@ import domino from 'domino'
 
 const L10N = c1.L10N
 
-describe('pcs.c1.L10n', () => {
-  const addDescriptionHTML = '<a data-action="add_title_description">before</a>'
-
+describe('pcs.c1.L10N', () => {
   describe('.localizeLabels()', () => {
-    it('add_title_description', () => {
-      const window = domino.createWindow(addDescriptionHTML)
+    it('addTitleDescription', () => {
+      const window = domino.createWindow(
+        '<p id="pagelib_edit_section_add_title_description">before</p>')
       const document = window.document
 
-      L10N.localizeLabels(document, { add_title_description: 'after' })
-      assert.strictEqual(document.body.querySelector('a').innerHTML, 'after')
+      L10N.localizeLabels(document, { addTitleDescription: 'after' })
+      assert.strictEqual(document.body.querySelector('p').innerHTML, 'after')
     })
   })
 })

--- a/test/pcs/c1/L10N.test.js
+++ b/test/pcs/c1/L10N.test.js
@@ -1,0 +1,19 @@
+import assert from 'assert'
+import { c1 } from '../../../build/wikimedia-page-library-pcs'
+import domino from 'domino'
+
+const L10N = c1.L10N
+
+describe('pcs.c1.L10n', () => {
+  const addDescriptionHTML = '<a data-action="add_title_description">before</a>'
+
+  describe('.localizeLabels()', () => {
+    it('add_title_description', () => {
+      const window = domino.createWindow(addDescriptionHTML)
+      const document = window.document
+
+      L10N.localizeLabels(document, { add_title_description: 'after' })
+      assert.strictEqual(document.body.querySelector('a').innerHTML, 'after')
+    })
+  })
+})

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -594,7 +594,7 @@ describe('CollapseTable', () => {
     const newCaptionFragment = pagelib.CollapseTable.test.newCaptionFragment
 
     describe('when no header text', () => {
-      const caption = newCaptionFragment(domino.createDocument(), 'title', [])
+      const caption = newCaptionFragment(domino.createDocument(), 'title', 'titleClass',[])
       it('the title is present', () => {
         assert.ok(caption.textContent.includes('title'))
       })
@@ -602,10 +602,14 @@ describe('CollapseTable', () => {
       it('no additional text is shown', () => {
         assert.ok(!caption.textContent.includes(','))
       })
+
+      it('title class is set to allow distinguishing types of tables', () => {
+        assert.ok(caption.querySelector('strong').classList.contains('titleClass'))
+      })
     })
 
     describe('when a one element header text', () => {
-      const caption = newCaptionFragment(domino.createDocument(), 'title', ['0'])
+      const caption = newCaptionFragment(domino.createDocument(), 'title', 'titleClass',['0'])
 
       it('the title is present', () => {
         assert.ok(caption.textContent.includes('title'))
@@ -621,7 +625,7 @@ describe('CollapseTable', () => {
     })
 
     describe('when a two element header text', () => {
-      const caption = newCaptionFragment(domino.createDocument(), 'title', ['0', '1'])
+      const caption = newCaptionFragment(domino.createDocument(), 'title', 'titleClass',['0', '1'])
 
       it('the title is present', () => {
         assert.ok(caption.textContent.includes('title'))


### PR DESCRIPTION
Allow clients to pass in localizable strings to setMulti().
This excludes the localizable strings for the footer.

Example:
```
pagelib.c1.PageMods.setMulti(document, {
  l10n: { 
    addTitleDescription: 'Titelbeschreibung bearbeiten',
    tableInfobox: 'Schnelle Fakten',
    tableOther: 'Weitere Informationen',
    tableClose: 'Schließen'
  }
})
```

Bug: https://phabricator.wikimedia.org/T205550