### PR TITLE
Rename areTablesCollapsed to areTablesInitiallyExpanded

### DIFF
--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -55,7 +55,7 @@ Setting parameter object fields:
 - theme: possible values in pagelib.c1.Themes: [DEFAULT, SEPIA, DARK, BLACK]
 - dimImages: boolean
 - margins: object with { top, right, bottom, left }
-- areTablesCollapsed: boolean
+- areTablesInitiallyExpanded: boolean (Default: tables are collapsed)
 - scrollTop: number of pixel for highest position to scroll to. Use this to adjust for any decor overlaying the viewport.
 
 (The first three fields don't have any equivalent separate call since those don't make sense to change after the fact.)
@@ -74,7 +74,7 @@ pagelib.c1.PageMods.setMulti(document, {
   theme: pagelib.c1.Themes.SEPIA,
   dimImages: true,
   margins: { top: '32px', right: '32px', bottom: '32px', left: '32px' },
-  areTablesCollapsed: true,
+  areTablesInitiallyExpanded: true,
   scrollTop: 64
 })
 ```

--- a/src/pcs/c1/PageMods.js
+++ b/src/pcs/c1/PageMods.js
@@ -35,8 +35,8 @@ const onPageLoad = (window, document) => {
  * during initial page load.
  * @param {!Document} document
  * @param {!{}} settings client settings
- *   { platform, clientVersion, l10n, theme, dimImages, margins, areTablesCollapsed, scrollTop,
- *   textSizeAdjustmentPercentage }
+ *   { platform, clientVersion, l10n, theme, dimImages, margins, areTablesInitiallyExpanded,
+ *   scrollTop, textSizeAdjustmentPercentage }
  * @param {?PageMods~Function} onSuccess callback
  * @return {void}
  */
@@ -56,7 +56,7 @@ const setMulti = (document, settings, onSuccess) => {
   if (settings.margins !== undefined) {
     BodySpacingTransform.setMargins(document.body, settings.margins)
   }
-  if (settings.areTablesCollapsed) {
+  if (settings.areTablesInitiallyExpanded) {
     CollapseTable.toggleCollapsedForAll(document.body)
   }
   if (settings.scrollTop !== undefined) {

--- a/test/pcs/c1/PageMods.test.js
+++ b/test/pcs/c1/PageMods.test.js
@@ -30,7 +30,7 @@ describe('pcs.c1.PageMods', () => {
         theme: Themes.DARK,
         dimImages: true,
         margins: { top: '1px', right: '2px', bottom: '3px', left: '4px' },
-        areTablesCollapsed: true
+        areTablesInitiallyExpanded: true
       }, () => { onSuccessCallbackCalled = true })
 
       assert.ok(document.documentElement.classList.contains('pagelib_theme_dark'))


### PR DESCRIPTION
The old name was misleading and lead to T227783.

Under the covers we only toggle the collapsed/expanded state for all
tables, which is only useful right when the page gets loaded before the
user makes any changes, hence the addition of "Initially".
The default is all tables are collapsed, so if the user wants the tables
expanded areTablesInitiallyExpanded should be set to true.

Bug: https://phabricator.wikimedia.org/T227783