### PR TITLE
mobile-html: DOMRect object from InteractionHandler response cannot be decoded on iOS

### DIFF
--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -122,6 +122,25 @@ class ReferenceLinkItem {
 }
 
 /**
+ * Get node's bounding rect as a plain object.
+ * @param {!Node} node
+ * @return {!Object<string, number>}
+ */
+const getBoundingClientRectAsPlainObject = node => {
+  const rect = node.getBoundingClientRect()
+  return {
+    top: rect.top,
+    right: rect.right,
+    bottom: rect.bottom,
+    left: rect.left,
+    width: rect.width,
+    height: rect.height,
+    x: rect.x,
+    y: rect.y
+  }
+}
+
+/**
  * Converts node to ReferenceItem.
  * @param {!Document} document
  * @param {!Node} node
@@ -129,7 +148,7 @@ class ReferenceLinkItem {
  */
 const referenceItemForNode = (document, node) => new ReferenceItem(
   closestReferenceClassElement(node).id,
-  node.getBoundingClientRect(),
+  getBoundingClientRectAsPlainObject(node),
   node.textContent,
   collectRefText(document, node)
 )

--- a/test/transform/ReferenceCollection.test.js
+++ b/test/transform/ReferenceCollection.test.js
@@ -48,7 +48,7 @@ describe('ReferenceCollection', () => {
   describe('.collectNearbyReferences()', () => {
     it('collects expected references group and selected index', () => {
 
-      const MOCK_RECT = { top: 0, left: 1, width: 2, height: 3 }
+      const MOCK_RECT = { top: 0, left: 1, right: 4, bottom: 0, width: 2, height: 3, x: 0, y: 0 }
 
       // Domino doesn't implement 'getBoundingClientRect' so
       // backfill it for testing methods which call it.


### PR DESCRIPTION
https://phabricator.wikimedia.org/T227907

I'm assuming this will work on Android since plain objects are passed in other places

Let me know if there's a better way to do this 🤔 