### PR TITLE
Add href to ReferenceCollection to collectNearbyReferences output

### DIFF
--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -92,17 +92,19 @@ const closestReferenceClassElement = sourceNode => {
  */
 class ReferenceItem {
   /**
-   * ReferenceItem construtor.
+   * ReferenceItem constructor.
    * @param {!string} id
    * @param {!DOMRect} rect
    * @param {?string} text
    * @param {?string} html
+   * @param {?string} href
    */
-  constructor(id, rect, text, html) {
+  constructor(id, rect, text, html, href) {
     this.id = id
     this.rect = rect
     this.text = text
     this.html = html
+    this.href = href
   }
 }
 
@@ -150,7 +152,8 @@ const referenceItemForNode = (document, node) => new ReferenceItem(
   closestReferenceClassElement(node).id,
   getBoundingClientRectAsPlainObject(node),
   node.textContent,
-  collectRefText(document, node)
+  collectRefText(document, node),
+  node.querySelector('A').getAttribute('href')
 )
 
 /**

--- a/test/transform/ReferenceCollection.test.js
+++ b/test/transform/ReferenceCollection.test.js
@@ -59,19 +59,23 @@ describe('ReferenceCollection', () => {
 
       assert.strictEqual(nearbyReferences.selectedIndex, 1)
       assert.deepEqual(nearbyReferences.referencesGroup, [
-        { id: 'cite_ref-a',
+        { href: '#cite_note-a',
+          id: 'cite_ref-a',
           rect: MOCK_RECT,
           text: '[4]',
           html: '0 1 2' },
-        { id: 'cite_ref-b',
+        { href: '#cite_note-b',
+          id: 'cite_ref-b',
           rect: MOCK_RECT,
           text: '[6]',
           html: '3 4 5' },
-        { id: 'cite_ref-c',
+        { href: '#cite_note-c',
+          id: 'cite_ref-c',
           rect: MOCK_RECT,
           text: '[7]',
           html: '6 7 8' },
-        { id: 'cite_ref-d',
+        { href: '#cite_note-d',
+          id: 'cite_ref-d',
           rect: MOCK_RECT,
           text: '[8]',
           html: '9 10 11' }


### PR DESCRIPTION
It's useful to know what the target link to the reference is for the
reference_clicked event in InteractionHandling.