### PR TITLE
Pass href with imageClicked action, don't pass natural size. Pass title and text for linkClicked actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/wikimedia/wikimedia-page-library/issues",
   "main": "build/wikimedia-page-library-transform.js",
   "scripts": {
-    "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html",
+    "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html --fix",
     "lint:all": "npm run -s lint .",
     "build": "NODE_ENV=production webpack -p",
     "build:debug": "NODE_ENV=development webpack --debug --output-pathinfo --mode=development",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": "https://github.com/wikimedia/wikimedia-page-library/issues",
   "main": "build/wikimedia-page-library-transform.js",
   "scripts": {
-    "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html --fix",
+    "lint": "eslint --cache --max-warnings 0 --ext .js --ext .json --ext .html",
     "lint:all": "npm run -s lint .",
     "build": "NODE_ENV=production webpack -p",
     "build:debug": "NODE_ENV=development webpack --debug --output-pathinfo --mode=development",

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -120,8 +120,9 @@ const postMessageForLinkWithHref = href => {
  * @return {void}
  */
 const postMessageForImageWithTarget = (target, href) => {
+  const canonicalHref = href.replace(/^\.\/.+:/g, './File:')
   postMessage(new Interaction(Actions.ImageClicked, {
-    href,
+    href: canonicalHref,
     src: target.getAttribute('src'),
     'data-file-width': target.getAttribute('data-file-width'),
     'data-file-height': target.getAttribute('data-file-height')

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -116,15 +116,13 @@ const postMessageForLinkWithHref = href => {
 /**
  * Posts message for an image click.
  * @param {!Element} target an image element
+ * @param {!string} href url for the image
  * @return {void}
  */
-const postMessageForImageWithTarget = target => {
+const postMessageForImageWithTarget = (target, href) => {
   postMessage(new Interaction(Actions.ImageClicked, {
+    href,
     src: target.getAttribute('src'),
-    // Image should be fetched by time it is tapped,
-    // so naturalWidth and height should be available.
-    width: target.naturalWidth,
-    height: target.naturalHeight,
     'data-file-width': target.getAttribute('data-file-width'),
     'data-file-height': target.getAttribute('data-file-height')
   }))
@@ -167,7 +165,7 @@ const postMessageForClickedItem = item => {
     postMessageForLinkWithHref(item.href)
     break
   case ItemType.image:
-    postMessageForImageWithTarget(item.target)
+    postMessageForImageWithTarget(item.target, item.href)
     break
   case ItemType.imagePlaceholder:
     postMessageForImagePlaceholderWithTarget(item.target)

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -113,7 +113,8 @@ const postMessageForLink = (target, href) => {
   }
   postMessage(new Interaction(Actions.LinkClicked, {
     href,
-    text: target.innerText
+    text: target.innerText,
+    title: target.title
   }))
 }
 

--- a/src/pcs/c1/InteractionHandling.js
+++ b/src/pcs/c1/InteractionHandling.js
@@ -102,16 +102,27 @@ const postMessage = interaction => {
 
 /**
  * Posts message for a link click.
+ * @param {!Element} target element
  * @param {!string} href url
  * @return {void}
  */
-const postMessageForLinkWithHref = href => {
+const postMessageForLink = (target, href) => {
   if (href[0] === '#') {
     CollapseTable.expandCollapsedTableIfItContainsElement(
       document.getElementById(href.substring(1)))
   }
-  postMessage(new Interaction(Actions.LinkClicked, { href }))
+  postMessage(new Interaction(Actions.LinkClicked, {
+    href,
+    text: target.innerText
+  }))
 }
+
+/**
+ * Canonical file href
+ * @param {!string} href url for the image
+ * @return {!string} canonicalized file href
+ */
+const canonicalFileHref = href => href && href.replace(/^\.\/.+:/g, './File:')
 
 /**
  * Posts message for an image click.
@@ -119,8 +130,8 @@ const postMessageForLinkWithHref = href => {
  * @param {!string} href url for the image
  * @return {void}
  */
-const postMessageForImageWithTarget = (target, href) => {
-  const canonicalHref = href.replace(/^\.\/.+:/g, './File:')
+const postMessageForImage = (target, href) => {
+  const canonicalHref = canonicalFileHref(href)
   postMessage(new Interaction(Actions.ImageClicked, {
     href: canonicalHref,
     src: target.getAttribute('src'),
@@ -132,14 +143,15 @@ const postMessageForImageWithTarget = (target, href) => {
 /**
  * Posts a message for a lazy load image placeholder click.
  * @param {!Element} innerPlaceholderSpan
+ * @param {!string} href url for the image
  * @return {void}
  */
-const postMessageForImagePlaceholderWithTarget = innerPlaceholderSpan => {
+const postMessageForImagePlaceholder = (innerPlaceholderSpan, href) => {
   const outerSpan = innerPlaceholderSpan.parentElement
+  const canonicalHref = canonicalFileHref(href)
   postMessage(new Interaction(Actions.ImageClicked, {
+    href: canonicalHref,
     src: outerSpan.getAttribute('data-src'),
-    width: outerSpan.getAttribute('data-width'),
-    height: outerSpan.getAttribute('data-height'),
     'data-file-width': outerSpan.getAttribute('data-data-file-width'),
     'data-file-height': outerSpan.getAttribute('data-data-file-height')
   }))
@@ -163,13 +175,13 @@ const postMessageForReferenceWithTarget = target => {
 const postMessageForClickedItem = item => {
   switch (item.type()) {
   case ItemType.link:
-    postMessageForLinkWithHref(item.href)
+    postMessageForLink(item.target, item.href)
     break
   case ItemType.image:
-    postMessageForImageWithTarget(item.target, item.href)
+    postMessageForImage(item.target, item.href)
     break
   case ItemType.imagePlaceholder:
-    postMessageForImagePlaceholderWithTarget(item.target)
+    postMessageForImagePlaceholder(item.target, item.href)
     break
   case ItemType.reference:
     postMessageForReferenceWithTarget(item.target)


### PR DESCRIPTION
- Fix for https://phabricator.wikimedia.org/T228536 , pass `href` similar to other actions. In this case it points to the original `File:` title
- Remove naturalWidth, naturalHeight - not sure this will be reliable and I don't think the clients need it, only the original width and height that's already included CC @sharvaniharan @nambatee 
- Fix for https://phabricator.wikimedia.org/T228535, pass `title` and `text` with `linkClicked`

It looks like the placeholder action doesn't work as it was (it sends a linkClicked event) - feel free to fix that here, otherwise it can be a follow on