### PR TITLE
WIP: Prevent placeholder to be wider than the viewport width on initial load

### DIFF
--- a/src/transform/WidenImage.css
+++ b/src/transform/WidenImage.css
@@ -72,5 +72,5 @@ div.gallerytext > p {
 
 /* Prevent image placeholder to be wider than the viewport */
 .gallerybox .pagelib_lazy_load_placeholder {
-  width: 100%!important;
+  width: 100% !important;
 }

--- a/src/transform/WidenImage.css
+++ b/src/transform/WidenImage.css
@@ -69,3 +69,8 @@ li.gallerybox div.thumb > div {
 div.gallerytext > p {
   margin-top: 0px !important;
 }
+
+/* Prevent image placeholder to be wider than the viewport */
+.gallerybox .pagelib_lazy_load_placeholder {
+  width: 100%!important;
+}


### PR DESCRIPTION
Bug: [T228287](https://phabricator.wikimedia.org/T228287)