### PR TITLE
Allow client to specify if and what edit buttons should be shown

### DIFF
--- a/docs/pcs/pcs.md
+++ b/docs/pcs/pcs.md
@@ -121,12 +121,23 @@ pagelib.c1.Page.getRevision()
 ```
 returns '907165344'
 
-#### setTextSizeAdjustmentPercentage
+#### setTextSizeAdjustmentPercentage(percentageString)
 Sets the text-adjust-size property percentage allowing native clients to adjust the font-size. This CSS property is not supported in all browsers, you can check which browsers support it in the following link, https://caniuse.com/#feat=text-size-adjust
 
 The input needs to be a string like '10%'. Example:
 ```
 pagelib.c1.Page.setTextSizeAdjustmentPercentage('10%')
+```
+
+#### setEditButtons(isEditable, isProtected, onSuccess)
+Enables or disables the edit buttons on the page. The default is edit buttons are off but it's probably best to not assume that.
+The second boolean is whether to show the protected edit pencils.
+
+All parameters are optional. Default is false, false.
+
+Example:
+```
+pagelib.c1.Page.setEditButtons(true, false)
 ```
 
 ### Sections

--- a/src/pcs/c1/Page.js
+++ b/src/pcs/c1/Page.js
@@ -2,6 +2,7 @@ import AdjustTextSize from '../../transform/AdjustTextSize'
 import BodySpacingTransform from '../../transform/BodySpacingTransform'
 import CollapseTable from '../../transform/CollapseTable'
 import DimImagesTransform from '../../transform/DimImagesTransform'
+import EditTransform from '../../transform/EditTransform'
 import L10N from './L10N'
 import LazyLoadTransformer from '../../transform/LazyLoadTransformer'
 import PlatformTransform from '../../transform/PlatformTransform'
@@ -153,6 +154,21 @@ const setTextSizeAdjustmentPercentage = (textSize, onSuccess) => {
 }
 
 /**
+ * Enables edit buttons to be shown (and which ones).
+ * @param {?boolean} isEditable true if edit buttons should be shown
+ * @param {?boolean} isProtected true if the protected edit buttons should be shown
+ * @param {?OnSuccess} onSuccess onSuccess callback
+ * @return {void}
+ */
+const setEditButtons = (isEditable, isProtected, onSuccess) => {
+  EditTransform.setEditButtons(document, isEditable, isProtected)
+
+  if (onSuccess instanceof Function) {
+    onSuccess()
+  }
+}
+
+/**
  * Gets the revision of the current mobile-html page.
  * @return {string}
  */
@@ -178,6 +194,7 @@ export default {
   setMargins,
   setScrollTop,
   setTextSizeAdjustmentPercentage,
+  setEditButtons,
   getRevision,
   testing: {
     getScroller

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -21,6 +21,27 @@ const ACTION_TITLE_PRONUNCIATION = 'title_pronunciation'
 const ACTION_ADD_TITLE_DESCRIPTION = 'add_title_description'
 
 /**
+ * Enables edit buttons to be shown (and which ones: protected or regular).
+ * @param {!HTMLDocument} document
+ * @param {?boolean} isEditable true if edit buttons should be shown
+ * @param {?boolean} isProtected true if the protected edit buttons should be shown
+ * @return {void}
+ */
+const setEditButtons = (document, isEditable = false, isProtected = false) => {
+  const classList = document.documentElement.classList
+  if (isEditable) {
+    classList.remove(CLASS.PROTECTION.FORBIDDEN)
+  } else {
+    classList.add(CLASS.PROTECTION.FORBIDDEN)
+  }
+  if (isProtected) {
+    classList.add(CLASS.PROTECTION.PROTECTED)
+  } else {
+    classList.remove(CLASS.PROTECTION.PROTECTED)
+  }
+}
+
+/**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLAnchorElement}
@@ -152,6 +173,7 @@ const newEditLeadSectionHeader = (document, pageDisplayTitle, titleDescription,
 export default {
   CLASS,
   ADD_TITLE_DESCRIPTION: IDS.ADD_TITLE_DESCRIPTION,
+  setEditButtons,
   newEditSectionButton,
   newEditSectionHeader,
   newEditLeadSectionHeader

--- a/test/pcs/c1/Page.test.js
+++ b/test/pcs/c1/Page.test.js
@@ -139,6 +139,21 @@ describe('pcs.c1.Page', () => {
     })
   })
 
+  describe('.setEditButtons()', () => {
+    it('simple', () =>  {
+      let callbackCalled = false
+      window = domino.createWindow(
+        '<html about="http://en.wikipedia.org/wiki/Special:Redirect/revision/907165344">')
+      document = window.document
+
+      Page.setEditButtons(false, true, () => { callbackCalled = true })
+
+      assert.ok(document.documentElement.classList.contains('no-editing'))
+      assert.ok(document.documentElement.classList.contains('page-protected'))
+      assert.ok(callbackCalled)
+    })
+  })
+
   describe('.getRevision()', () => {
     it('all', () => {
       window = domino.createWindow(

--- a/test/transform/EditTransform.test.js
+++ b/test/transform/EditTransform.test.js
@@ -4,6 +4,36 @@ import pagelib from '../../build/wikimedia-page-library-transform'
 const editTransform = pagelib.EditTransform
 
 describe('EditTransform', () => {
+  describe('.setEditButtons()', () => {
+    const protection = editTransform.CLASS.PROTECTION
+    let document
+
+    beforeEach(() => {
+      document = fixtureIO.documentFromFixtureFile('EditTransform.html')
+    })
+
+    it('(document) = (document, false, false)', () => {
+      editTransform.setEditButtons(document)
+      assert.ok(document.documentElement.classList.contains(protection.FORBIDDEN))
+      assert.ok(!document.documentElement.classList.contains(protection.PROTECTED))
+    })
+    it('false, true', () => {
+      editTransform.setEditButtons(document, false, true)
+      assert.ok(document.documentElement.classList.contains(protection.FORBIDDEN))
+      assert.ok(document.documentElement.classList.contains(protection.PROTECTED))
+    })
+    it('true, false', () => {
+      editTransform.setEditButtons(document, true, false)
+      assert.ok(!document.documentElement.classList.contains(protection.FORBIDDEN))
+      assert.ok(!document.documentElement.classList.contains(protection.PROTECTED))
+    })
+    it('true, true', () => {
+      editTransform.setEditButtons(document, true, true)
+      assert.ok(!document.documentElement.classList.contains(protection.FORBIDDEN))
+      assert.ok(document.documentElement.classList.contains(protection.PROTECTED))
+    })
+  })
+
   describe('.newEditSectionHeader(0, 2)', () => {
     let document
     let element


### PR DESCRIPTION
Adds new function Page.setEditButtons(isEditable, isProtected).

Bug: [T228437](https://phabricator.wikimedia.org/T228437)