### PR TITLE
Performance: Prefer firstChild/nextSibling to childNodes

### DIFF
--- a/src/transform/ReferenceCollection.js
+++ b/src/transform/ReferenceCollection.js
@@ -63,9 +63,13 @@ const collectRefText = (document, source) => {
   frag.appendChild(fragDiv)
   // eslint-disable-next-line require-jsdoc
   const cloneNodeIntoFragmentDiv = node => fragDiv.appendChild(node.cloneNode(true))
-  Array.prototype.slice.call(refTextContainer.childNodes)
-    .filter(NodeUtilities.isNodeTypeElementOrText)
-    .forEach(cloneNodeIntoFragmentDiv)
+  let cur = refTextContainer.firstChild
+  while (cur) {
+    if (NodeUtilities.isNodeTypeElementOrText(cur)) {
+      cloneNodeIntoFragmentDiv(cur)
+    }
+    cur = cur.nextSibling
+  }
 
   const removalSelector = 'link, style, sup[id^=cite_ref], .mw-cite-backlink'
   Polyfill.querySelectorAll(fragDiv, removalSelector)

--- a/test/transform/CollapseTable.test.js
+++ b/test/transform/CollapseTable.test.js
@@ -43,22 +43,22 @@ describe('CollapseTable', () => {
     })
     it('non-leading/trailing non-breaking spaces converted to breaking spaces', () => {
       assert.equal(stringWithNormalizedWhitespace(
-        domino.createDocument('hi&nbsp;hi').childNodes[0].textContent
+        domino.createDocument('hi&nbsp;hi').firstChild.textContent
       ), 'hi hi')
     })
     it('leading and trailing non-breaking spaces trimmed', () => {
       assert.equal(stringWithNormalizedWhitespace(
-        domino.createDocument('&nbsp;hi hi&nbsp;').childNodes[0].textContent
+        domino.createDocument('&nbsp;hi hi&nbsp;').firstChild.textContent
       ), 'hi hi')
     })
     it('tabs trimmed', () => {
       assert.equal(stringWithNormalizedWhitespace(
-        domino.createDocument('\thi\t').childNodes[0].textContent
+        domino.createDocument('\thi\t').firstChild.textContent
       ), 'hi')
     })
     it('non-leading tabs converted to breaking spaces', () => {
       assert.equal(stringWithNormalizedWhitespace(
-        domino.createDocument('hi\thi').childNodes[0].textContent
+        domino.createDocument('hi\thi').firstChild.textContent
       ), 'hi hi')
     })
   })
@@ -854,7 +854,7 @@ describe('CollapseTable', () => {
       const contentBlock = window.document.querySelector('.content_block')
       assert.ok(contentBlock)
       assert.deepEqual(contentBlock.parentNode.parentNode.tagName, 'BODY')
-      const collapsibleContainer = contentBlock.childNodes[0]
+      const collapsibleContainer = contentBlock.firstChild
       assert.ok(collapsibleContainer)
       assert.ok(collapsibleContainer.classList.contains('pagelib_collapse_table_container'))
       const table = collapsibleContainer.querySelector('.infobox')
@@ -873,7 +873,7 @@ describe('CollapseTable', () => {
       const section = window.document.querySelector('section')
       assert.ok(section)
       assert.deepEqual(section.parentNode.tagName, 'BODY')
-      const collapsibleContainer = section.childNodes[0]
+      const collapsibleContainer = section.firstChild
       assert.ok(collapsibleContainer)
       assert.ok(collapsibleContainer.classList.contains('pagelib_collapse_table_container'))
       const table = collapsibleContainer.querySelector('.infobox')

--- a/test/transform/EditTransform.test.js
+++ b/test/transform/EditTransform.test.js
@@ -47,20 +47,20 @@ describe('EditTransform', () => {
       assert.ok(element)
     })
     it('creates h2 element', () => {
-      assert.equal(element.childNodes.item(0).nodeName, 'H2')
+      assert.equal(element.firstChild.nodeName, 'H2')
     })
     it('has all required attributes', () => {
-      assert.ok(element.childNodes.item(0).hasAttribute('data-id'))
+      assert.ok(element.firstChild.hasAttribute('data-id'))
     })
     it('has child nodes', () => {
-      assert.ok(element.childNodes.item(0).hasChildNodes)
+      assert.ok(element.firstChild.firstChild)
     })
     it('has edit container and pencil', () => {
       assert.ok(element.innerHTML.includes('pagelib_edit_section_link'))
       assert.ok(element.innerHTML.includes('pagelib_edit_section_link_container'))
     })
     it('has desired title', () => {
-      const text = element.childNodes.item(0).textContent
+      const text = element.firstChild.textContent
       assert.ok(text.includes('Title'))
     })
   })
@@ -75,7 +75,7 @@ describe('EditTransform', () => {
     })
 
     it('creates h3 element', () => {
-      assert.equal(element.childNodes.item(0).nodeName, 'H3')
+      assert.equal(element.firstChild.nodeName, 'H3')
     })
   })
 
@@ -89,7 +89,7 @@ describe('EditTransform', () => {
     })
 
     it('creates h4 element', () => {
-      assert.equal(element.childNodes.item(0).nodeName, 'H4')
+      assert.equal(element.firstChild.nodeName, 'H4')
     })
   })
 
@@ -103,7 +103,7 @@ describe('EditTransform', () => {
     })
 
     it('creates h2 element', () => {
-      assert.equal(element.childNodes.item(0).nodeName, 'H2')
+      assert.equal(element.firstChild.nodeName, 'H2')
     })
     it('does not have edit container or pencil', () => {
       assert.ok(!element.innerHTML.includes('pagelib_edit_section_link'))


### PR DESCRIPTION
Per Domino's readme file,[1] we should prefer traversing the DOM tree
using The `first/lastChild` and `next/previousSibling` properties rather than
`childNodes`. Doing the latter converts the linked list representation of
the DOM tree structure to an array-based representation, hurting
performance when modifying the tree.

Updated tests that were accessing `childNodes[0]` rather than `firstChild`
as well, to reinforce this.

[1] https://github.com/fgnass/domino#optimization