### PR TITLE
Fix: Guard against errors in a try-catch block when reading styles

### DIFF
--- a/src/transform/ElementUtilities.js
+++ b/src/transform/ElementUtilities.js
@@ -29,7 +29,16 @@ const findClosestAncestor = (el, selector) => {
  */
 const closestInlineStyle = (element, property, value) => {
   for (let el = element; el; el = el.parentElement) {
-    const thisValue = el.style[property]
+    let thisValue
+
+    // Wrap in a try-catch block to avoid Domino crashing on a malformed style declaration.
+    // T229521
+    try {
+      thisValue = el.style[property]
+    } catch (e) {
+      continue
+    }
+
     if (thisValue) {
       if (value === undefined) {
         return el


### PR DESCRIPTION
Domino sometimes errors out when attempting to parse malformed style
declarations, and this is crashing in prod. Add a try-catch block to
handle this.

Phab: https://phabricator.wikimedia.org/T229521