### PR TITLE
Add getTableOfContents function to pcs Page module

### DIFF
--- a/src/pcs/c1/Page.js
+++ b/src/pcs/c1/Page.js
@@ -172,6 +172,39 @@ const getRevision = () => {
 }
 
 /**
+ * Get structured table of contents data
+ * @return {!Array}
+ */
+const getTableOfContents = () => {
+  const sections = document.querySelectorAll('section')
+  const result = []
+  const levelCounts = new Array(10).fill(0)
+  let lastLevel = 0;
+
+  [].forEach.call(sections, section => {
+    const id = parseInt(section.getAttribute('data-mw-section-id'), 10)
+    if (id < 1) {
+      return
+    }
+    const headerEl = section.firstChild
+    const level = parseInt(headerEl.tagName.charAt(1), 10) - 1
+    if (level < lastLevel) {
+      levelCounts.fill(0, level)
+    }
+    lastLevel = level
+    levelCounts[level - 1]++
+    result.push({
+      level,
+      section: id,
+      number: levelCounts.slice(0, level).map(n => n.toString()).join('.'),
+      anchor: headerEl.getAttribute('id'),
+      html: headerEl.innerHTML.trim()
+    })
+  })
+  return result
+}
+
+/**
  * Gets the Scroller object. Just for testing!
  * @return {{setScrollTop, scrollWithDecorOffset}}
  */
@@ -256,6 +289,7 @@ export default {
   setTextSizeAdjustmentPercentage,
   setEditButtons,
   getRevision,
+  getTableOfContents,
   testing: {
     getScroller
   }

--- a/test/pcs/c1/Page.test.js
+++ b/test/pcs/c1/Page.test.js
@@ -182,4 +182,30 @@ describe('pcs.c1.Page', () => {
       assert.strictEqual(Page.getRevision(), '907165344')
     })
   })
+
+  describe('.getTableOfContents()', () => {
+    it('all', () => {
+      window = domino.createWindow(`
+        <section data-mw-section-id="0">Foo</section>
+        <section data-mw-section-id="1" id="Foo"><h2>Foo</h2></section>
+        <section data-mw-section-id="2" id="Foo"><h3>Foo</h3></section>
+        <section data-mw-section-id="-1" id="Foo"><h5>Foo</h5></section>
+        <section data-mw-section-id="3" id="Foo"><h4>Foo</h4></section>
+        <section data-mw-section-id="4" id="Foo"><h3>Foo</h3></section>
+        <section data-mw-section-id="-2" id="Foo"><h5>Foo</h5></section>
+        <section data-mw-section-id="5" id="Foo"><h4>Foo</h4></section>
+        <section data-mw-section-id="6" id="Foo"><h3>Foo</h3></section>
+        <section data-mw-section-id="7" id="Foo"><h2>Foo</h2></section>
+      `)
+      document = window.document
+
+      const result = Page.getTableOfContents()
+      const expectedNumbers = ['1', '1.1', '1.1.1', '1.2', '1.2.1', '1.3', '2']
+      assert.strictEqual(result.length, 7, 'result should have 7 entries (3 excluded)')
+      assert.strictEqual(result.length, expectedNumbers.length)
+      for (let i = 0; i < expectedNumbers.length; i++) {
+        assert.strictEqual(result[i].number, expectedNumbers[i])
+      }
+    })
+  })
 })


### PR DESCRIPTION
Incorporates the TOC building function that currently exists in PCS
in lib/metadata.js.

Bug: https://phabricator.wikimedia.org/T230035