### PR TITLE
Fix: Get the section header element correctly

### DIFF
--- a/src/pcs/c1/Page.js
+++ b/src/pcs/c1/Page.js
@@ -186,7 +186,7 @@ const getTableOfContents = () => {
     if (id < 1) {
       return
     }
-    const headerEl = section.firstChild
+    const headerEl = section.querySelector('h1,h2,h3,h4,h5,h6')
     const level = parseInt(headerEl.tagName.charAt(1), 10) - 1
     if (level < lastLevel) {
       levelCounts.fill(0, level)

--- a/test/pcs/c1/Page.test.js
+++ b/test/pcs/c1/Page.test.js
@@ -187,15 +187,15 @@ describe('pcs.c1.Page', () => {
     it('all', () => {
       window = domino.createWindow(`
         <section data-mw-section-id="0">Foo</section>
-        <section data-mw-section-id="1" id="Foo"><h2>Foo</h2></section>
-        <section data-mw-section-id="2" id="Foo"><h3>Foo</h3></section>
-        <section data-mw-section-id="-1" id="Foo"><h5>Foo</h5></section>
-        <section data-mw-section-id="3" id="Foo"><h4>Foo</h4></section>
-        <section data-mw-section-id="4" id="Foo"><h3>Foo</h3></section>
-        <section data-mw-section-id="-2" id="Foo"><h5>Foo</h5></section>
-        <section data-mw-section-id="5" id="Foo"><h4>Foo</h4></section>
-        <section data-mw-section-id="6" id="Foo"><h3>Foo</h3></section>
-        <section data-mw-section-id="7" id="Foo"><h2>Foo</h2></section>
+        <section data-mw-section-id="1" id="Foo"><div><h2 id="Foo">Foo</h2></div></section>
+        <section data-mw-section-id="2" id="Foo"><div><h3 id="Foo">Foo</h3></div></section>
+        <section data-mw-section-id="-1" id="Foo"><div><h5 id="Foo">Foo</h5></div></section>
+        <section data-mw-section-id="3" id="Foo"><div><h4 id="Foo">Foo</h4></div></section>
+        <section data-mw-section-id="4" id="Foo"><div><h3 id="Foo">Foo</h3></div></section>
+        <section data-mw-section-id="-2" id="Foo"><div><h5 id="Foo">Foo</h5></div></section>
+        <section data-mw-section-id="5" id="Foo"><div><h4 id="Foo">Foo</h4></div></section>
+        <section data-mw-section-id="6" id="Foo"><div><h3 id="Foo">Foo</h3></div></section>
+        <section data-mw-section-id="7" id="Foo"><div><h2 id="Foo">Foo</h2></div></section>
       `)
       document = window.document
 
@@ -203,9 +203,13 @@ describe('pcs.c1.Page', () => {
       const expectedNumbers = ['1', '1.1', '1.1.1', '1.2', '1.2.1', '1.3', '2']
       assert.strictEqual(result.length, 7, 'result should have 7 entries (3 excluded)')
       assert.strictEqual(result.length, expectedNumbers.length)
-      for (let i = 0; i < expectedNumbers.length; i++) {
-        assert.strictEqual(result[i].number, expectedNumbers[i])
-      }
+      result.forEach((tocSection, idx) => {
+        assert.ok(tocSection.level, 'level should be present')
+        assert.ok(tocSection.section,'section should be present')
+        assert.strictEqual(tocSection.number, expectedNumbers[idx], 'should have correct number')
+        assert.ok(tocSection.anchor, 'anchor should be present')
+        assert.ok(tocSection.html, 'html should be present')
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes an issue caused by a structural difference between raw Parsoid
HTML and PCS mobile-html. In Parsoid HTML, a section's heading element is
always the first child of a section element, but in mobile-html it's
wrapped in an enclosing div.