### PR TITLE
Add 'notheme'

### DIFF
--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -27,7 +27,8 @@ styles with only the things which need tweaking.
   color: #36c;
 }
 
-.notheme .pagelib_theme_div_do_not_apply_baseline {
+.notheme,
+.pagelib_theme_div_do_not_apply_baseline {
   color: #000;
 }
 

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -41,21 +41,21 @@ styles with only the things which need tweaking.
 
 /* baseline table */
 .pagelib_theme_dark .content table,
-.pagelib_theme_dark .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content tr,
 .pagelib_theme_dark .content th {
   background: #27292d !important;
   color: #f8f9fa !important;
 }
 .pagelib_theme_sepia .content table,
-.pagelib_theme_sepia .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content tr,
 .pagelib_theme_sepia .content th {
   background: #f0e6d6 !important;
   color: #222 !important;
 }
 .pagelib_theme_black .content table,
-.pagelib_theme_black .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content tr,
 .pagelib_theme_black .content th {
   background: #222 !important;
@@ -63,24 +63,24 @@ styles with only the things which need tweaking.
 }
 
 /* baseline div, span, ul, li */
-.pagelib_theme_dark .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_dark .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content ul,
 .pagelib_theme_dark .content ol,
 .pagelib_theme_dark .content li {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }
-.pagelib_theme_sepia .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_sepia .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content ul,
 .pagelib_theme_sepia .content ol,
 .pagelib_theme_sepia .content li {
   background-color: inherit !important;
   color: #222 !important;
 }
-.pagelib_theme_black .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_black .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content ul,
 .pagelib_theme_black .content ol,
 .pagelib_theme_black .content li {
@@ -89,13 +89,13 @@ styles with only the things which need tweaking.
 }
 
 /* baseline border color */
-.pagelib_theme_dark .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_dark .content :not(.notheme, .pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
-.pagelib_theme_sepia .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_sepia .content :not(.notheme, .pagelib_theme_div_do_not_apply_baseline) {
   border-color: #cbc8c1 !important;
 }
-.pagelib_theme_black .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_black .content :not(.notheme, .pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
 

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -27,7 +27,7 @@ styles with only the things which need tweaking.
   color: #36c;
 }
 
-.notheme {
+.pagelib_theme_div_do_not_apply_baseline {
   color: #000;
 }
 
@@ -40,21 +40,21 @@ styles with only the things which need tweaking.
 
 /* baseline table */
 .pagelib_theme_dark .content table,
-.pagelib_theme_dark .content td:not(.notheme),
+.pagelib_theme_dark .content td:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content tr,
 .pagelib_theme_dark .content th {
   background: #27292d !important;
   color: #f8f9fa !important;
 }
 .pagelib_theme_sepia .content table,
-.pagelib_theme_sepia .content td:not(.notheme),
+.pagelib_theme_sepia .content td:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content tr,
 .pagelib_theme_sepia .content th {
   background: #f0e6d6 !important;
   color: #222 !important;
 }
 .pagelib_theme_black .content table,
-.pagelib_theme_black .content td:not(.notheme),
+.pagelib_theme_black .content td:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content tr,
 .pagelib_theme_black .content th {
   background: #222 !important;
@@ -62,24 +62,24 @@ styles with only the things which need tweaking.
 }
 
 /* baseline div, span, ul, li */
-.pagelib_theme_dark .content div:not(.notheme),
-.pagelib_theme_dark .content span:not(.notheme),
+.pagelib_theme_dark .content div:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content span:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content ul,
 .pagelib_theme_dark .content ol,
 .pagelib_theme_dark .content li {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }
-.pagelib_theme_sepia .content div:not(.notheme),
-.pagelib_theme_sepia .content span:not(.notheme),
+.pagelib_theme_sepia .content div:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content span:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content ul,
 .pagelib_theme_sepia .content ol,
 .pagelib_theme_sepia .content li {
   background-color: inherit !important;
   color: #222 !important;
 }
-.pagelib_theme_black .content div:not(.notheme),
-.pagelib_theme_black .content span:not(.notheme),
+.pagelib_theme_black .content div:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content span:not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content ul,
 .pagelib_theme_black .content ol,
 .pagelib_theme_black .content li {
@@ -88,13 +88,13 @@ styles with only the things which need tweaking.
 }
 
 /* baseline border color */
-.pagelib_theme_dark .content :not(.notheme) {
+.pagelib_theme_dark .content :not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
-.pagelib_theme_sepia .content :not(.notheme) {
+.pagelib_theme_sepia .content :not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #cbc8c1 !important;
 }
-.pagelib_theme_black .content :not(.notheme) {
+.pagelib_theme_black .content :not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
 

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -19,17 +19,18 @@ styles with only the things which need tweaking.
   background: #000;
 }
 
-/* baseline anchor */
-.pagelib_theme_dark a, .pagelib_theme_black a {
-  color: #69f;
-}
-.pagelib_theme_sepia a {
-  color: #36c;
-}
-
 .notheme,
 .pagelib_theme_div_do_not_apply_baseline {
   color: #000;
+}
+
+/* baseline anchor */
+.pagelib_theme_dark a:not(.notheme), 
+.pagelib_theme_black a:not(.notheme) {
+  color: #69f;
+}
+.pagelib_theme_sepia a:not(.notheme) {
+  color: #36c;
 }
 
 /* external anchor */
@@ -40,24 +41,24 @@ styles with only the things which need tweaking.
 }
 
 /* baseline table */
-.pagelib_theme_dark .content table,
+.pagelib_theme_dark .content table:not(.notheme),
 .pagelib_theme_dark .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_dark .content tr,
-.pagelib_theme_dark .content th {
+.pagelib_theme_dark .content tr:not(.notheme),
+.pagelib_theme_dark .content th:not(.notheme) {
   background: #27292d !important;
   color: #f8f9fa !important;
 }
-.pagelib_theme_sepia .content table,
+.pagelib_theme_sepia .content table:not(.notheme),
 .pagelib_theme_sepia .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_sepia .content tr,
-.pagelib_theme_sepia .content th {
+.pagelib_theme_sepia .content tr:not(.notheme),
+.pagelib_theme_sepia .content th:not(.notheme) {
   background: #f0e6d6 !important;
   color: #222 !important;
 }
-.pagelib_theme_black .content table,
+.pagelib_theme_black .content table:not(.notheme),
 .pagelib_theme_black .content td:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_black .content tr,
-.pagelib_theme_black .content th {
+.pagelib_theme_black .content tr:not(.notheme),
+.pagelib_theme_black .content th:not(.notheme) {
   background: #222 !important;
   color: #f8f9fa !important;
 }
@@ -65,25 +66,25 @@ styles with only the things which need tweaking.
 /* baseline div, span, ul, li */
 .pagelib_theme_dark .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_dark .content ul,
-.pagelib_theme_dark .content ol,
-.pagelib_theme_dark .content li {
+.pagelib_theme_dark .content ul:not(.notheme),
+.pagelib_theme_dark .content ol:not(.notheme),
+.pagelib_theme_dark .content li:not(.notheme) {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }
 .pagelib_theme_sepia .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_sepia .content ul,
-.pagelib_theme_sepia .content ol,
-.pagelib_theme_sepia .content li {
+.pagelib_theme_sepia .content ul:not(.notheme),
+.pagelib_theme_sepia .content ol:not(.notheme),
+.pagelib_theme_sepia .content li:not(.notheme) {
   background-color: inherit !important;
   color: #222 !important;
 }
 .pagelib_theme_black .content div:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content span:not(.notheme, .pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_black .content ul,
-.pagelib_theme_black .content ol,
-.pagelib_theme_black .content li {
+.pagelib_theme_black .content ul:not(.notheme),
+.pagelib_theme_black .content ol:not(.notheme),
+.pagelib_theme_black .content li:not(.notheme) {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -27,7 +27,7 @@ styles with only the things which need tweaking.
   color: #36c;
 }
 
-.pagelib_theme_div_do_not_apply_baseline {
+.notheme .pagelib_theme_div_do_not_apply_baseline {
   color: #000;
 }
 
@@ -40,21 +40,21 @@ styles with only the things which need tweaking.
 
 /* baseline table */
 .pagelib_theme_dark .content table,
-.pagelib_theme_dark .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content tr,
 .pagelib_theme_dark .content th {
   background: #27292d !important;
   color: #f8f9fa !important;
 }
 .pagelib_theme_sepia .content table,
-.pagelib_theme_sepia .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content tr,
 .pagelib_theme_sepia .content th {
   background: #f0e6d6 !important;
   color: #222 !important;
 }
 .pagelib_theme_black .content table,
-.pagelib_theme_black .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content td:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content tr,
 .pagelib_theme_black .content th {
   background: #222 !important;
@@ -62,24 +62,24 @@ styles with only the things which need tweaking.
 }
 
 /* baseline div, span, ul, li */
-.pagelib_theme_dark .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_dark .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_dark .content ul,
 .pagelib_theme_dark .content ol,
 .pagelib_theme_dark .content li {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }
-.pagelib_theme_sepia .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_sepia .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_sepia .content ul,
 .pagelib_theme_sepia .content ol,
 .pagelib_theme_sepia .content li {
   background-color: inherit !important;
   color: #222 !important;
 }
-.pagelib_theme_black .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_black .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content div:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content span:not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline),
 .pagelib_theme_black .content ul,
 .pagelib_theme_black .content ol,
 .pagelib_theme_black .content li {
@@ -88,13 +88,13 @@ styles with only the things which need tweaking.
 }
 
 /* baseline border color */
-.pagelib_theme_dark .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_dark .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
-.pagelib_theme_sepia .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_sepia .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #cbc8c1 !important;
 }
-.pagelib_theme_black .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_black .content :not(.notheme):not(.pagelib_theme_div_do_not_apply_baseline) {
   border-color: #43464a !important;
 }
 

--- a/src/transform/ThemeTransform.css
+++ b/src/transform/ThemeTransform.css
@@ -27,7 +27,7 @@ styles with only the things which need tweaking.
   color: #36c;
 }
 
-.pagelib_theme_div_do_not_apply_baseline {
+.notheme {
   color: #000;
 }
 
@@ -40,21 +40,21 @@ styles with only the things which need tweaking.
 
 /* baseline table */
 .pagelib_theme_dark .content table,
-.pagelib_theme_dark .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content td:not(.notheme),
 .pagelib_theme_dark .content tr,
 .pagelib_theme_dark .content th {
   background: #27292d !important;
   color: #f8f9fa !important;
 }
 .pagelib_theme_sepia .content table,
-.pagelib_theme_sepia .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content td:not(.notheme),
 .pagelib_theme_sepia .content tr,
 .pagelib_theme_sepia .content th {
   background: #f0e6d6 !important;
   color: #222 !important;
 }
 .pagelib_theme_black .content table,
-.pagelib_theme_black .content td:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content td:not(.notheme),
 .pagelib_theme_black .content tr,
 .pagelib_theme_black .content th {
   background: #222 !important;
@@ -62,24 +62,24 @@ styles with only the things which need tweaking.
 }
 
 /* baseline div, span, ul, li */
-.pagelib_theme_dark .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_dark .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_dark .content div:not(.notheme),
+.pagelib_theme_dark .content span:not(.notheme),
 .pagelib_theme_dark .content ul,
 .pagelib_theme_dark .content ol,
 .pagelib_theme_dark .content li {
   background-color: inherit !important;
   color: #f8f9fa !important;
 }
-.pagelib_theme_sepia .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_sepia .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_sepia .content div:not(.notheme),
+.pagelib_theme_sepia .content span:not(.notheme),
 .pagelib_theme_sepia .content ul,
 .pagelib_theme_sepia .content ol,
 .pagelib_theme_sepia .content li {
   background-color: inherit !important;
   color: #222 !important;
 }
-.pagelib_theme_black .content div:not(.pagelib_theme_div_do_not_apply_baseline),
-.pagelib_theme_black .content span:not(.pagelib_theme_div_do_not_apply_baseline),
+.pagelib_theme_black .content div:not(.notheme),
+.pagelib_theme_black .content span:not(.notheme),
 .pagelib_theme_black .content ul,
 .pagelib_theme_black .content ol,
 .pagelib_theme_black .content li {
@@ -88,13 +88,13 @@ styles with only the things which need tweaking.
 }
 
 /* baseline border color */
-.pagelib_theme_dark .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_dark .content :not(.notheme) {
   border-color: #43464a !important;
 }
-.pagelib_theme_sepia .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_sepia .content :not(.notheme) {
   border-color: #cbc8c1 !important;
 }
-.pagelib_theme_black .content :not(.pagelib_theme_div_do_not_apply_baseline) {
+.pagelib_theme_black .content :not(.notheme) {
   border-color: #43464a !important;
 }
 

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -6,7 +6,7 @@ import Polyfill from './Polyfill'
 // difficult to describe as CSS selectors.
 const CONSTRAINT = {
   IMAGE_PRESUMES_WHITE_BACKGROUND: 'pagelib_theme_image_presumes_white_background',
-  DIV_DO_NOT_APPLY_BASELINE: 'pagelib_theme_div_do_not_apply_baseline'
+  DIV_DO_NOT_APPLY_BASELINE: 'notheme'
 }
 
 // Theme to CSS classes.

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -6,7 +6,7 @@ import Polyfill from './Polyfill'
 // difficult to describe as CSS selectors.
 const CONSTRAINT = {
   IMAGE_PRESUMES_WHITE_BACKGROUND: 'pagelib_theme_image_presumes_white_background',
-  DIV_DO_NOT_APPLY_BASELINE: 'notheme'
+  DIV_DO_NOT_APPLY_BASELINE: 'pagelib_theme_div_do_not_apply_baseline'
 }
 
 // Theme to CSS classes.


### PR DESCRIPTION
https://phabricator.wikimedia.org/T229286

`classifyElements` is by far the slowest part of preparing `mobile-html`. It's not sustainable to keep adding exclusions to the list of specific [filenames](https://github.com/wikimedia/wikimedia-page-library/blob/master/src/transform/ThemeTransform.js#L44-L45) and [query selectors](https://github.com/wikimedia/wikimedia-page-library/blob/master/src/transform/ThemeTransform.js#L83-L98). 

I'm proposing we add `notheme` and request editors add it to the appropriate templates ahead of the launch of `mobile-html`. This will allow the `mobile-html` endpoint to stop calling `classifyElements`. There is some precedent for this with `nomobile` (now obviated by TemplateStyles) but will need to confirm that this is a viable option. 