### PR TITLE
Expose new functions to improve mobile-html perf

### DIFF
--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -46,7 +46,7 @@ const setEditButtons = (document, isEditable = false, isProtected = false) => {
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLAnchorElement}
  */
-const newEditSectionLink = (document, index, href) => {
+const newEditSectionLink = (document, index, href = '') => {
   const link = document.createElement('a')
   link.href = href
   link.setAttribute(DATA_ATTRIBUTE.SECTION_INDEX, index)

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -46,9 +46,9 @@ const setEditButtons = (document, isEditable = false, isProtected = false) => {
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLAnchorElement}
  */
-const newEditSectionLink = (document, index) => {
+const newEditSectionLink = (document, index, href) => {
   const link = document.createElement('a')
-  link.href = ''
+  link.href = href
   link.setAttribute(DATA_ATTRIBUTE.SECTION_INDEX, index)
   link.setAttribute(DATA_ATTRIBUTE.ACTION, ACTION_EDIT_SECTION)
   link.classList.add(CLASS.LINK)
@@ -60,14 +60,38 @@ const newEditSectionLink = (document, index) => {
  * @param {!number} index The zero-based index of the section.
  * @return {!HTMLSpanElement}
  */
-const newEditSectionButton = (document, index) => {
+const newEditSectionButton = (document, index, link) => {
   const container = document.createElement('span')
   container.classList.add(CLASS.LINK_CONTAINER)
 
-  const link = newEditSectionLink(document, index)
+  if (!link) {
+    link = newEditSectionLink(document, index)
+  }
   container.appendChild(link)
 
   return container
+}
+
+
+/**
+ * @param {!Document} document
+ * @param {!number} index The zero-based index of the section.
+ * @param {!HTMLElement} header The header element.
+ * @return {!HTMLDivElement}
+ */
+const newEditSectionWrapper = (document, index) => {
+  const element = document.createElement('div')
+  element.className = CLASS.SECTION_HEADER
+  return element
+}
+
+/**
+ * @param {!HTMLDivElement} wrapper
+ * @param {!HTMLElement} header The header element.
+ */
+const appendEditSectionHeader = (wrapper, header) => {
+  header.className = CLASS.TITLE
+  wrapper.appendChild(header)
 }
 
 /**
@@ -80,14 +104,12 @@ const newEditSectionButton = (document, index) => {
  * @return {!HTMLElement}
  */
 const newEditSectionHeader = (document, index, level, titleHTML, showEditPencil = true) => {
-  const element = document.createElement('div')
-  element.className = CLASS.SECTION_HEADER
 
+  const element = newEditSectionWrapper(document, index)
   const title = document.createElement(`h${level}`)
   title.innerHTML = titleHTML || ''
-  title.className = CLASS.TITLE
   title.setAttribute(DATA_ATTRIBUTE.SECTION_INDEX, index)
-  element.appendChild(title)
+  appendEditSectionHeader(element, title)
 
   if (showEditPencil) {
     const button = newEditSectionButton(document, index)
@@ -171,10 +193,13 @@ const newEditLeadSectionHeader = (document, pageDisplayTitle, titleDescription,
 }
 
 export default {
+  appendEditSectionHeader,
   CLASS,
   ADD_TITLE_DESCRIPTION: IDS.ADD_TITLE_DESCRIPTION,
   setEditButtons,
   newEditSectionButton,
   newEditSectionHeader,
-  newEditLeadSectionHeader
+  newEditSectionWrapper,
+  newEditLeadSectionHeader,
+  newEditSectionLink
 }

--- a/src/transform/EditTransform.js
+++ b/src/transform/EditTransform.js
@@ -44,6 +44,7 @@ const setEditButtons = (document, isEditable = false, isProtected = false) => {
 /**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
+ * @param {!string} href The href for the link
  * @return {!HTMLAnchorElement}
  */
 const newEditSectionLink = (document, index, href = '') => {
@@ -58,25 +59,25 @@ const newEditSectionLink = (document, index, href = '') => {
 /**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
+ * @param {!HTMLElement} link The link element
  * @return {!HTMLSpanElement}
  */
 const newEditSectionButton = (document, index, link) => {
   const container = document.createElement('span')
   container.classList.add(CLASS.LINK_CONTAINER)
 
-  if (!link) {
-    link = newEditSectionLink(document, index)
+  let actualLink = link
+  if (!actualLink) {
+    actualLink = newEditSectionLink(document, index)
   }
-  container.appendChild(link)
+  container.appendChild(actualLink)
 
   return container
 }
 
-
 /**
  * @param {!Document} document
  * @param {!number} index The zero-based index of the section.
- * @param {!HTMLElement} header The header element.
  * @return {!HTMLDivElement}
  */
 const newEditSectionWrapper = (document, index) => {
@@ -88,6 +89,7 @@ const newEditSectionWrapper = (document, index) => {
 /**
  * @param {!HTMLDivElement} wrapper
  * @param {!HTMLElement} header The header element.
+ * @return {void}
  */
 const appendEditSectionHeader = (wrapper, header) => {
   header.className = CLASS.TITLE

--- a/src/transform/LazyLoadTransform.ts
+++ b/src/transform/LazyLoadTransform.ts
@@ -176,6 +176,7 @@ const loadPlaceholder = (document: Document, placeholder: HTMLSpanElement): HTML
 export default {
   CLASSES,
   PLACEHOLDER_CLASS,
+  isLazyLoadable,
   queryLazyLoadableImages,
   convertImagesToPlaceholders,
   loadPlaceholder

--- a/src/transform/LazyLoadTransform.ts
+++ b/src/transform/LazyLoadTransform.ts
@@ -179,5 +179,6 @@ export default {
   isLazyLoadable,
   queryLazyLoadableImages,
   convertImagesToPlaceholders,
+  convertImageToPlaceholder,
   loadPlaceholder
 }

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -51,14 +51,15 @@ const footballTemplateImageFilenameRegex =
  * @param  {!HTMLImageElement} image
  * @return {!boolean}
  */
-const imagePresumesWhiteBackground = image =>
-  // if (footballTemplateImageFilenameRegex.test(image.src)) {
-  //   return false
-  // }
-  // if (image.classList.contains('mwe-math-fallback-image-inline')) {
-  //   return false
-  // }
-  false// !ElementUtilities.closestInlineStyle(image, 'background')
+const imagePresumesWhiteBackground = image => {
+  if (footballTemplateImageFilenameRegex.test(image.src)) {
+    return false
+  }
+  if (image.classList.contains('mwe-math-fallback-image-inline')) {
+    return false
+  }
+  return !ElementUtilities.closestInlineStyle(image, 'background')
+}
 
 
 /**

--- a/src/transform/ThemeTransform.js
+++ b/src/transform/ThemeTransform.js
@@ -51,15 +51,15 @@ const footballTemplateImageFilenameRegex =
  * @param  {!HTMLImageElement} image
  * @return {!boolean}
  */
-const imagePresumesWhiteBackground = image => {
-  if (footballTemplateImageFilenameRegex.test(image.src)) {
-    return false
-  }
-  if (image.classList.contains('mwe-math-fallback-image-inline')) {
-    return false
-  }
-  return !ElementUtilities.closestInlineStyle(image, 'background')
-}
+const imagePresumesWhiteBackground = image =>
+  // if (footballTemplateImageFilenameRegex.test(image.src)) {
+  //   return false
+  // }
+  // if (image.classList.contains('mwe-math-fallback-image-inline')) {
+  //   return false
+  // }
+  false// !ElementUtilities.closestInlineStyle(image, 'background')
+
 
 /**
  * Annotate elements with CSS classes that can be used by CSS rules. The classes themselves are not


### PR DESCRIPTION
Expose methods to operate on individual elements instead of the entire document. This way, the  mobileapps service can walk the DOM once and pass the appropriate elements to the page library for manipulation instead of having the page library perform a `querySelector` for every transform.

This needs to be merged and released before the [corresponding mobileapps change](https://gerrit.wikimedia.org/r/c/mediawiki/services/mobileapps/+/544936) can be merged. 