### PR TITLE
Set accessibility role for footer items

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
-### v9.3.1
+### v9.3.2
  - Feature: pagelib.c1.Page.getProtection()
+
+### v9.3.1
+ - Fix: Set accessibility role for footer items
 
 ### v9.3.0
  - Breaking: Include section information in payload for page issues and similar pages footer items

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,8 @@
 ### v9.3.2
- - Feature: pagelib.c1.Page.getProtection()
-
-### v9.3.1
  - Fix: Set accessibility role for footer items
+
+ ### v9.3.1
+ - Feature: pagelib.c1.Page.getProtection()
 
 ### v9.3.0
  - Breaking: Include section information in payload for page issues and similar pages footer items

--- a/src/transform/FooterMenu.js
+++ b/src/transform/FooterMenu.js
@@ -102,7 +102,7 @@ class MenuItem {
 const documentFragmentForMenuItem = (menuItem, document) => {
   const item = document.createElement('div')
   item.className = 'pagelib_footer_menu_item'
-
+  item.role = 'menuitem'
   const containerAnchor = document.createElement('a')
   containerAnchor.addEventListener('click', () => {
     menuItem.clickHandler(menuItem.payload)


### PR DESCRIPTION
Setting the accessibility role will allow VoiceOver users to select the entire footer item, instead of having to select individual labels

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/AccessibilityRoles.html