### PR TITLE
Use Polyfill instead of Array.from to get an array from querySelectorAll

### DIFF
--- a/src/pcs/c1/L10N.js
+++ b/src/pcs/c1/L10N.js
@@ -1,5 +1,6 @@
 import CollapseTable from '../../transform/CollapseTable'
 import EditTransform from '../../transform/EditTransform'
+import Polyfill from '../../transform/Polyfill'
 
 const selectors = {
   addTitleDescription: `#${EditTransform.ADD_TITLE_DESCRIPTION}`,
@@ -18,7 +19,7 @@ const selectors = {
 const localizeLabels = localizedStrings => {
   for (const [key, selector] of Object.entries(selectors)) {
     if (localizedStrings[key]) {
-      const elements = Array.from(document.querySelectorAll(selector))
+      const elements = Polyfill.querySelectorAll(document, selector)
       for (const element of elements) {
         element.innerHTML = localizedStrings[key]
       }

--- a/src/transform/LazyLoadTransformer.js
+++ b/src/transform/LazyLoadTransformer.js
@@ -1,6 +1,7 @@
 import CollapseTable from './CollapseTable'
 import ElementUtilities from './ElementUtilities'
 import LazyLoadTransform from './LazyLoadTransform'
+import Polyfill from './Polyfill'
 import Throttle from './Throttle'
 
 const EVENT_TYPES = ['scroll', 'resize', CollapseTable.SECTION_TOGGLED_EVENT_TYPE]
@@ -49,7 +50,7 @@ export default class {
    */
   collectExistingPlaceholders(element) {
     const placeholders
-      = Array.from(element.querySelectorAll(`.${LazyLoadTransform.PLACEHOLDER_CLASS}`))
+      = Polyfill.querySelectorAll(element, `.${LazyLoadTransform.PLACEHOLDER_CLASS}`)
     this._placeholders = this._placeholders.concat(placeholders)
     this._register()
   }

--- a/src/transform/SectionUtilities.ts
+++ b/src/transform/SectionUtilities.ts
@@ -1,10 +1,11 @@
+const Polyfill = require('./Polyfill').default
 /**
  * get Section Offsets object to handle quick scrolling in the table of contents
  * @param  {!HTMLBodyElement} body HTML body element DOM object.
  * @return {!object} section offsets object
  */
 const getSectionOffsets = (body: HTMLBodyElement): object => {
-    const sections = Array.from(body.querySelectorAll('section'))
+    const sections = Polyfill.querySelectorAll(body, 'section')
     return {
         sections: sections.reduce((results: Array<object>, section: HTMLElement) => {
             const id = section.getAttribute('data-mw-section-id');


### PR DESCRIPTION
Fixes incompatibility with parsoid visual diff browser